### PR TITLE
feat: [ANI-11] 기초 덱 생성 및 카드 분배 로직 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "@nestjs/websockets": "^11.1.13",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
-        "socket.io": "^4.8.3"
+        "socket.io": "^4.8.3",
+        "uuid": "^13.0.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",
@@ -9811,6 +9812,19 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "@nestjs/websockets": "^11.1.13",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
-    "socket.io": "^4.8.3"
+    "socket.io": "^4.8.3",
+    "uuid": "^13.0.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
@@ -65,6 +66,12 @@
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },
+    "moduleNameMapper": {
+      "^uuid$": "uuid" 
+    },
+    "transformIgnorePatterns": [
+      "node_modules/(?!(uuid)/)"
+    ],
     "collectCoverageFrom": [
       "**/*.(t|j)s"
     ],

--- a/src/modules/game/game-setup.service.spec.ts
+++ b/src/modules/game/game-setup.service.spec.ts
@@ -1,0 +1,127 @@
+import { GameSetupService } from './game-setup.service';
+import { CardSuit, CardType } from '../../shared/enums/game.enum';
+import { Card, Player } from 'src/shared/interfaces/game.interface';
+
+describe('GameSetupService', () => {
+  let service: GameSetupService;
+
+  beforeEach(() => {
+    service = new GameSetupService();
+  });
+
+  describe('createDeck', () => {
+    let deck: Card[];
+    const suits = Object.values(CardSuit);
+
+    beforeEach(() => {
+      deck = service.createDeck();
+    })
+
+    test('총 76장의 카드가 생성되어야 한다 (1~10까지 * 4장 + 특수카드 5종 * 4장 + 공격(1,2,3단계)*4장 + 와일드카드 4장)', () => {
+      expect(deck.length).toBe(76);
+    });
+
+    test('생성된 모든 카드는 서로 다른 고유 ID를 가져야 한다', () => {
+      const ids = new Set(deck.map(c => c.id));
+      expect(ids.size).toBe(76); // 중복이 없어야 함
+    });
+
+    test.each(suits)(
+      '%s 동물의 특수 카드는 5장이 존재해야 한다',
+      (suit) => {
+        const specials = deck.filter(c => c.suit === suit && c.type === CardType.SPECIAL);
+        expect(specials.length).toBe(5);
+      }
+    );
+
+    test.each(suits)(
+      '%s 동물의 공격 카드는 3장이 존재해야 한다',
+      (suit) => {
+        const attack = deck.filter(c => c.suit === suit && c.type === CardType.ATTACK);
+        expect(attack.length).toBe(3);
+      }
+    );
+
+    test.each(suits)(
+      '%s 동물의 와일드 카드는 1장이 존재해야 한다',
+      (suit) => {
+        const wild = deck.filter(c => c.suit === suit && c.type === CardType.WILD);
+        expect(wild.length).toBe(1);
+      }
+    );
+
+    test.each(suits)(
+      '각 동물의 숫자카드는 1부터 10까지 누락없이 생성되어야 한다',
+      (suit) => {
+        const actualNumbers = deck
+          .filter(c => c.suit === suit && c.type === CardType.NUMBER)
+          .map(c => parseInt(c.value))
+          .sort((a, b) => a - b);
+
+        const expectedNumbers = Array.from({ length: 10 }, (_, i) => i + 1)
+
+        expect(actualNumbers).toEqual(expectedNumbers);
+      }
+    );
+  });
+
+  describe('shuffle', () => {
+    it('셔플 후에도 카드의 총 개수와 구성 요소는 변함이 없어야 한다', () => {
+      const originalDeck = service.createDeck();
+      const shuffledDeck = [...originalDeck];
+      service.shuffle(shuffledDeck);
+
+      expect(shuffledDeck.length).toBe(originalDeck.length);
+
+      // 원본의 ID 리스트와 셔플된 ID 리스트를 정렬해서 비교 (구성 요소 동일 확인)
+      const originalIds = originalDeck.map(c => c.id).sort();
+      const shuffledIds = shuffledDeck.map(c => c.id).sort();
+      expect(shuffledIds).toEqual(originalIds);
+    });
+
+    it('셔플 후의 덱은 원본 덱과 순서가 달라야 한다', () => {
+      const deck1 = service.createDeck();
+      const deck2 = [...deck1];
+      service.shuffle(deck2);
+
+      // 전체 순서 비교
+      expect(deck1).not.toEqual(deck2);
+    });
+  });
+
+  describe('distributeCards', () => {
+    const playerScenarios = [
+      { count: 2, expectedRemaining: 76 - 14 },
+      { count: 3, expectedRemaining: 76 - 21 },
+      { count: 4, expectedRemaining: 76 - 28 },
+    ];
+    const cardsToBeDistributed = 7;
+
+    const createMockPlayer = (id: number): Player => ({
+      userId: `user_${id}`,
+      nickname: `nickname_${id}`,
+      cardCount: 0,
+      hand: [],
+      isReady: true,
+      isOut: false,
+      role: 'PLAYER',
+    });
+
+    test.each(playerScenarios)(
+      `$count인 플레이어가 ${cardsToBeDistributed}장씩 분배받아야 한다. 남은 덱은 $expectedRemaining장이어야 한다`,
+      ({ count, expectedRemaining }) => {
+        // 플레이어 수만큼 가짜 배열 생성
+        const players: Player[] = Array.from({ length: count }, (_, i) => createMockPlayer(i));
+        const deck = service.createDeck();
+
+        // 실행
+        const { updatedPlayers, remainingDeck } = service.distributeCards(deck, players, cardsToBeDistributed);
+
+        // 검증
+        expect(updatedPlayers.length).toBe(count); // 분배가 모든 인원에게 잘 되었는지 체크
+        updatedPlayers.forEach(p => expect(p.hand.length).toBe(cardsToBeDistributed)); // 분배 된 카드 갯수 체크
+        expect(remainingDeck.length).toBe(expectedRemaining); // 남은 카드의 갯수 체크
+      }
+    );
+  });
+});

--- a/src/modules/game/game-setup.service.ts
+++ b/src/modules/game/game-setup.service.ts
@@ -1,0 +1,102 @@
+import { Injectable, OnModuleInit } from '@nestjs/common';
+import { v4 as uuidv4 } from 'uuid';
+import { CardSuit, CardType } from '../../shared/enums/game.enum';
+import { Card, Player } from '../../shared/interfaces/game.interface';
+
+@Injectable()
+export class GameSetupService {
+  private readonly SUITS = Object.values(CardSuit);
+  private readonly SPECIAL_TYPES = ['SHIELD', 'EVADE', 'PLUS_ONE', 'REVERSE', 'JUMP'];
+
+  // 카드의 '원형'을 저장할 마스터 데이터 (Flyweight Factory 역할) => id만 제거하고 이후에 매핑
+  private readonly masterDeck: Omit<Card, 'id'>[] = [];
+
+  // 모듈이 초기화될 때 카드의 마스터 데이터를 생성
+  constructor() {
+    this.initializeMasterDeck();
+  }
+
+  /**
+   * 서버 시작 시 딱 한 번만 실행되어 76장의 카드 원형을 생성합니다.
+   */
+  private initializeMasterDeck(): void {
+    this.SUITS.forEach((suit) => {
+      // 숫자 카드 (1~10)
+      for (let i = 1; i <= 10; i++) {
+        this.masterDeck.push(this.createCardPrototype(suit, CardType.NUMBER, i.toString(), 0));
+      }
+      // 공격 카드 (1~3)
+      for (let i = 1; i <= 3; i++) {
+        this.masterDeck.push(this.createCardPrototype(suit, CardType.ATTACK, `SWORD_${i}`, i));
+      }
+      // 특수 카드 (5종)
+      this.SPECIAL_TYPES.forEach((type) => {
+        this.masterDeck.push(this.createCardPrototype(suit, CardType.SPECIAL, type, 0));
+      });
+      // 와일드 카드 (1장)
+      this.masterDeck.push(this.createCardPrototype(suit, CardType.WILD, 'WILD', 0));
+    });
+  }
+
+  // omit 객체로 틀을 만들어주는 함수
+  createCardPrototype(suit: CardSuit, type: CardType, value: string, power: number): Omit<Card, "id"> {
+    return {
+      suit,
+      type,
+      value,
+      power,
+      assetKey: `${suit}_${type}_${value}`.toUpperCase(),
+    };
+  }
+
+  /**
+   * Omit 객체에 id 매핑
+   */
+  createDeck(): Card[] {
+    return this.masterDeck.map((prototype) => ({
+      ...prototype,
+      id: uuidv4(), // 외연적 상태(고유 식별자) 주입
+    }));
+  }
+
+  /**
+   * 셔플 (shuffle)
+   * Fisher-Yates 알고리즘을 사용하여 원본 배열의 순서를 섞습니다.
+   */
+  shuffle(deck: Card[]): void {
+    for (let i = deck.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [deck[i], deck[j]] = [deck[j], deck[i]];
+    }
+  }
+
+  /**
+   * 카드 분배 (distributeCards)
+   * 플레이어들에게 지정된 수만큼 카드를 나눠주고 남은 덱을 반환합니다.
+   */
+  distributeCards(deck: Card[], players: Player[], count: number) {
+    const totalRequired = players.length * count;
+    if (deck.length < totalRequired) {
+      throw new Error('부족한 카드 개수: 분배할 수 없습니다.');
+    }
+
+    // 원본 덱 보호를 위한 복사 (고전파 테스트의 불변성 검증 통과용)
+    const remainingDeck = [...deck];
+    
+    const updatedPlayers = players.map((player) => {
+      // 덱의 앞에서부터 순차적으로 추출
+      const hand = remainingDeck.splice(0, count);
+      
+      return {
+        ...player,
+        hand: [...player.hand, ...hand],
+        cardCount: player.hand.length + hand.length,
+      };
+    });
+
+    return {
+      updatedPlayers: updatedPlayers,
+      remainingDeck,
+    };
+  }
+}

--- a/src/shared/enums/game.enum.ts
+++ b/src/shared/enums/game.enum.ts
@@ -3,16 +3,16 @@ export enum CardSuit {
   CAT = 'CAT',
   RABBIT = 'RABBIT',
   BEAR = 'BEAR',
-  WILD = 'WILD', // 동물 변경용
 }
 
 export enum CardType {
   NUMBER = 'NUMBER',   // 일반 숫자 카드
   ATTACK = 'ATTACK',   // 칼 자루 공격 카드
   SPECIAL = 'SPECIAL', // 방패, 화살표, 한 장 더 내기, 점프, 역방향
+  WILD = 'WILD', // 동물 변경용
 }
 
 export enum GameDirection {
-    CLOCKWISE = 1, // 시계 방향
-    COUNTER_CLOCKWISE = -1, // 반시계 방향
+  CLOCKWISE = 1, // 시계 방향
+  COUNTER_CLOCKWISE = -1, // 반시계 방향
 }


### PR DESCRIPTION
## ✅ 작업 내용
- 마스터 데이터 기반의 덱 빌더 구현
`CardSuit`(4종)와 `CardType`을 조합하여 기획서에 명시된 총 76장의 카드를 자동 생성하는 로직 구축
숫자(10장), 공격(3장), 특수(5종), 와일드 카드가 각 종족별로 정확히 배분되도록 구현함

- Fisher-Yates 셔플 알고리즘 도입
편향(Bias) 없는 무작위성을 보장하기 위해 Fisher-Yates 알고리즘을 사용하여 덱 섞기 기능을 구현하였음

- 유연한 카드 분배 시스템
플레이어 수에 관계없이 지정된 수량(7장)의 카드를 순차적으로 분배하고, 남은 덱 상태를 반환하는 `distributeCards` 메서드 추가

## 🔍 핵심 설계 포인트
- Flyweight 패턴을 통한 자원 최적화
  - 본질적 상태(Shared): 카드의 고유 스펙(Suit, Power, AssetKey 등)은 서버 구동 시 masterDeck에 딱 한 번만 생성되어 메모리를 공유함

  - 외연적 상태(Unique): 각 게임 세션마다 UUID만 새롭게 부여하여, 수천 개의 게임 방이 생겨도 메모리 사용량을 최소한으로 유지하도록 설계

- 게임의 핵심 로직을 의도했던대로 정밀하게 작동하기 위해 TDD를 적용하여 구현하였음

<img width="922" height="432" alt="image" src="https://github.com/user-attachments/assets/8cbf835e-0c23-425c-b6b3-edf9613c91b3" />

<img width="473" height="45" alt="image" src="https://github.com/user-attachments/assets/2e315916-0873-468a-aa9b-5460c6dfd280" />
<img width="460" height="36" alt="image" src="https://github.com/user-attachments/assets/ed7eff40-58e6-4e3b-845d-f97e22a6301c" />

테스트 커버리지 97.14% (Statements 기준)

closes ANI-11