### PR TITLE
feat: [ANI-25] 게임 시작 및 초기화

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",
         "@eslint/js": "^9.18.0",
+        "@golevelup/ts-jest": "^3.0.0",
         "@nestjs/cli": "^11.0.0",
         "@nestjs/schematics": "^11.0.0",
         "@nestjs/testing": "^11.0.1",
@@ -944,6 +945,13 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@golevelup/ts-jest": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@golevelup/ts-jest/-/ts-jest-3.0.0.tgz",
+      "integrity": "sha512-ei0cvUKrVv8cJBW6df54yeod8PyzR2LTYG6wJ1xm+213p7HnThw5ShQcRH0/hhhnXnJCLrpmJM7e6fkRjHUF1g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
     "@eslint/js": "^9.18.0",
+    "@golevelup/ts-jest": "^3.0.0",
     "@nestjs/cli": "^11.0.0",
     "@nestjs/schematics": "^11.0.0",
     "@nestjs/testing": "^11.0.1",

--- a/src/modules/game/game-setup.service.ts
+++ b/src/modules/game/game-setup.service.ts
@@ -7,7 +7,7 @@ import * as crypto from 'crypto';
 @Injectable()
 export class GameSetupService {
   private readonly SUITS = Object.values(CardSuit);
-  private readonly SPECIAL_TYPES = ['SHIELD', 'EVADE', 'PLUS_ONE', 'REVERSE', 'JUMP'];
+  private readonly SPECIAL_TYPES = ['SHIELD', 'EVADE', 'BONUS', 'REVERSE', 'JUMP'];
 
   // 카드의 '원형'을 저장할 마스터 데이터 (Flyweight Factory 역할) => id만 제거하고 이후에 매핑
   private readonly masterDeck: Omit<Card, 'id'>[] = [];
@@ -46,7 +46,7 @@ export class GameSetupService {
       type,
       value,
       power,
-      assetKey: `${suit}_${type}_${value}`.toUpperCase(),
+      assetKey: `${suit}_${type}_${value}`,
     };
   }
 

--- a/src/modules/game/game.service.spec.ts
+++ b/src/modules/game/game.service.spec.ts
@@ -1,0 +1,301 @@
+import { WsException } from "@nestjs/websockets";
+import { CardSuit, CardType, GameDirection } from "src/shared/enums/game.enum";
+import { Card, GameRoom, Player } from "src/shared/interfaces/game.interface";
+import { v4 as uuidv4 } from 'uuid';
+import { GameSetupService } from "./game-setup.service";
+import { GameService } from "./game.service";
+import { RoomService } from "../socket/room.service";
+import { LogType } from "src/shared/enums/log.enum";
+import { createMock } from '@golevelup/ts-jest';
+
+describe('GameService (Unit)', () => {
+  let service: GameService;
+  let gameSetupService: jest.Mocked<GameSetupService>;
+  let roomService: jest.Mocked<RoomService>;
+
+  let host: ReturnType<typeof mockUser>;
+  let room: GameRoom;
+
+  beforeEach(() => {
+    gameSetupService = createMock<GameSetupService>();
+    roomService = createMock<RoomService>();
+
+    service = new GameService(gameSetupService, roomService);
+
+    host = mockUser();
+    room = createMockRoom(host);
+
+    roomService.getUserRoom.mockReturnValue(room.roomId);
+    roomService.getRoom.mockReturnValue(room);
+    roomService.createSystemLog.mockReturnValue({
+      id: 'log-id',
+      type: LogType.GAME_START,
+      actorId: host.userId,
+      actorName: host.nickname,
+      timestamp: Date.now(),
+      payload: { message: 'message' },
+    });
+
+    const mockDeck = Array.from({ length: 76 }, () => createMockCard());
+
+    gameSetupService.createDeck.mockReturnValue(mockDeck);
+
+    gameSetupService.distributeCards.mockImplementation((deck, players, count) => {
+      const updatedPlayers = players.map(p => ({
+        ...p,
+        hand: Array.from({ length: count }, () => createMockCard()),
+        cardCount: count,
+      }));
+
+      return {
+        updatedPlayers,
+        remainingDeck: deck.slice(players.length * count),
+      };
+    });
+  });
+
+  describe('startGame', () => {
+
+    it('방장이 아닌 유저가 시작하면 에러가 발생해야 한다', () => {
+      const guest = mockUser();
+      room.players.push(createPlayer(guest));
+
+      expect(() => {
+        service.startGame(guest.userId);
+      }).toThrow(WsException);
+    });
+
+    it('플레이어가 2명 미만이면 시작할 수 없다', () => {
+      expect(() => {
+        service.startGame(host.userId);
+      }).toThrow(WsException);
+    });
+
+    it('이미 PLAYING 상태이면 시작할 수 없다', () => {
+      const guest = mockUser();
+      room.players.push(createPlayer(guest, true));
+
+      room.status = 'PLAYING';
+
+      expect(() => {
+        service.startGame(host.userId);
+      }).toThrow(WsException);
+    });
+
+    it('모든 플레이어가 준비 상태가 아니면 시작할 수 없다', () => {
+      const guest = mockUser();
+      room.players.push(createPlayer(guest, false));
+
+      expect(() => {
+        service.startGame(host.userId);
+      }).toThrow(WsException);
+    });
+
+    it('게임 시작 시 모든 플레이어는 7장의 카드를 받아야 한다', () => {
+      const guest = mockUser();
+      room.players.push(createPlayer(guest, true));
+
+      const updatedRoom = service.startGame(host.userId);
+
+      updatedRoom.players
+        .filter(p => p.role === 'PLAYER')
+        .forEach(p => {
+          expect(p.hand.length).toBe(7);
+          expect(p.cardCount).toBe(7);
+        });
+    });
+
+    it('lastCard가 설정되어야 한다', () => {
+      const guest = mockUser();
+      room.players.push(createPlayer(guest, true));
+
+      const updatedRoom = service.startGame(host.userId);
+
+      expect(updatedRoom.lastCard).not.toBeNull();
+    });
+
+    it('첫 카드는 NUMBER 카드여야 한다 (특수 카드 skip)', () => {
+      const guest = mockUser();
+      room.players.push(createPlayer(guest, true));
+
+      const specialCard = createMockCard({ type: CardType.ATTACK });
+      const numberCard = createMockCard({ type: CardType.NUMBER });
+
+      gameSetupService.distributeCards.mockReturnValue({
+        updatedPlayers: room.players,
+        remainingDeck: [specialCard, specialCard, numberCard],
+      });
+
+      const updatedRoom = service.startGame(host.userId);
+
+      expect(updatedRoom.lastCard?.type).toBe(CardType.NUMBER);
+    });
+
+    it('상태가 PLAYING으로 변경되어야 한다', () => {
+      const guest = mockUser();
+      room.players.push(createPlayer(guest, true));
+
+      const updatedRoom = service.startGame(host.userId);
+
+      expect(updatedRoom.status).toBe('PLAYING');
+    });
+
+    it('turnOwner는 플레이어 중 한 명이어야 한다', () => {
+      const guest = mockUser();
+      room.players.push(createPlayer(guest, true));
+
+      const updatedRoom = service.startGame(host.userId);
+
+      const playerIds = updatedRoom.players
+        .filter(p => p.role === 'PLAYER')
+        .map(p => p.userId);
+
+      expect(playerIds).toContain(updatedRoom.turnOwner);
+    });
+
+    it('direction은 CLOCKWISE로 초기화되어야 한다', () => {
+      const guest = mockUser();
+      room.players.push(createPlayer(guest, true));
+
+      const updatedRoom = service.startGame(host.userId);
+
+      expect(updatedRoom.direction).toBe(GameDirection.CLOCKWISE);
+    });
+
+    it('attackStack과 currentPower는 0으로 초기화되어야 한다', () => {
+      const guest = mockUser();
+      room.players.push(createPlayer(guest, true));
+
+      room.attackStack = 5;
+      room.currentPower = 3;
+
+      const updatedRoom = service.startGame(host.userId);
+
+      expect(updatedRoom.attackStack).toBe(0);
+      expect(updatedRoom.currentPower).toBe(0);
+    });
+
+    it('lastActionId가 초기화되어야 한다', () => {
+      const guest = mockUser();
+      room.players.push(createPlayer(guest, true));
+
+      room.lastActionId = 10;
+
+      const updatedRoom = service.startGame(host.userId);
+
+      expect(updatedRoom.lastActionId).toBe(0);
+    });
+
+    it('로그가 생성되어야 한다', () => {
+      const guest = mockUser();
+      room.players.push(createPlayer(guest, true));
+
+      service.startGame(host.userId);
+
+      expect(roomService.createSystemLog).toHaveBeenCalledWith(
+        room,
+        room.hostId,
+        LogType.GAME_START,
+        '게임이 시작되었습니다.'
+      );
+
+      expect(roomService.pushLog).toHaveBeenCalled();
+    });
+
+    it('게임 시작 시 카드 셋업 파이프라인이 실행되어야 한다', () => {
+      const guest = mockUser();
+      room.players.push(createPlayer(guest, true));
+
+      service.startGame(host.userId);
+
+      expect(gameSetupService.createDeck).toHaveBeenCalled();
+      expect(gameSetupService.shuffle).toHaveBeenCalledWith(expect.any(Array));
+
+      expect(gameSetupService.distributeCards).toHaveBeenCalledWith(
+        expect.any(Array),
+        expect.arrayContaining([
+          expect.objectContaining({ role: 'PLAYER' })
+        ]),
+        7
+      );
+    });
+
+    it('관전자는 카드 분배 대상에서 제외되어야 한다', () => {
+      const guest = mockUser();
+      const spectator = mockUser();
+
+      room.players.push(createPlayer(guest, true));
+      room.players.push(createSpectator(spectator));
+
+      const updatedRoom = service.startGame(host.userId);
+
+      const spec = updatedRoom.players.find(p => p.role === 'SPECTATOR');
+
+      expect(spec?.hand.length).toBe(0);
+    });
+
+  });
+});
+
+// helper functions for tests
+function createMockRoom(host: ReturnType<typeof mockUser>): GameRoom {
+  return {
+    roomId: uuidv4(),
+    hostId: host.userId,
+    attackStack: 0,
+    currentPower: 0,
+    lastCard: null,
+    drawPile: [],
+    discardPile: [],
+    lastActionId: 0,
+    turnOwner: null,
+    isBonusTurn: false,
+    direction: GameDirection.CLOCKWISE,
+    players: [createPlayer(host, true)],
+    status: 'WAITING',
+    recentLogs: [],
+  };
+}
+
+function createPlayer(user: ReturnType<typeof mockUser>, isReady = false): Player {
+  return {
+    ...user,
+    hand: [],
+    cardCount: 0,
+    isReady,
+    isOut: false,
+    role: 'PLAYER',
+  };
+}
+
+function createSpectator(user: ReturnType<typeof mockUser>): Player {
+  return {
+    ...user,
+    hand: [],
+    cardCount: 0,
+    isReady: false,
+    isOut: false,
+    role: 'SPECTATOR',
+  };
+}
+
+function mockUser() {
+  const userId = uuidv4();
+  return {
+    userId,
+    nickname: `Guest_${userId.slice(0, 5)}`,
+    isGuest: true,
+  };
+}
+
+function createMockCard(overrides?: Partial<Card>): Card {
+  return {
+    id: uuidv4(),
+    suit: CardSuit.RABBIT,
+    type: CardType.NUMBER,
+    value: '1',
+    power: 0,
+    assetKey: 'rabbit_number_1',
+    ...overrides,
+  };
+}

--- a/src/modules/game/game.service.ts
+++ b/src/modules/game/game.service.ts
@@ -1,0 +1,133 @@
+import { Card, GameRoom, Player } from "src/shared/interfaces/game.interface";
+import { GameSetupService } from "./game-setup.service";
+import { RoomService } from "../socket/room.service";
+import { WsException } from "@nestjs/websockets";
+import { CardType, GameDirection } from "../../shared/enums/game.enum";
+import { LogType } from "src/shared/enums/log.enum";
+import { Injectable } from "@nestjs/common";
+
+@Injectable()
+export class GameService {
+  constructor(
+    private readonly gameSetupService: GameSetupService,
+    private readonly roomService: RoomService
+  ) { }
+
+  startGame(userId: string): GameRoom {
+    const room = this.getValidRoom(userId);
+
+    this.validateGameStart(room, userId);
+
+    const { updatedPlayers, remainingDeck } =
+      this.setupPlayersAndDeck(room);
+
+    const firstCard = this.selectFirstCard(remainingDeck);
+
+    this.initializeGameState(room, updatedPlayers, remainingDeck, firstCard);
+
+    // TODO (ANI-13): 향후 영속 로그 저장을 위해 LogRepository 연동 및 비동기 큐 도입 예정
+    this.roomService.pushLog(
+      room,
+      this.roomService.createSystemLog(room, room.hostId, LogType.GAME_START, '게임이 시작되었습니다.')
+    );
+
+    return room;
+  }
+
+  private getValidRoom(userId: string): GameRoom {
+    const roomId = this.roomService.getUserRoom(userId);
+    if (!roomId) throw new WsException('User is not in any room');
+
+    const room = this.roomService.getRoom(roomId);
+    if (!room) throw new WsException('Room not found');
+
+    return room;
+  }
+
+  private validateGameStart(room: GameRoom, userId: string) {
+    if (room.hostId !== userId) {
+      throw new WsException('Only host can start the game');
+    }
+
+    if (room.status !== 'WAITING') {
+      throw new WsException('Game already started or finished');
+    }
+
+    const players = room.players.filter(p => p.role === 'PLAYER');
+
+    if (players.length < 2) {
+      throw new WsException('Not enough players to start');
+    }
+
+    if (!players.every(p => p.isReady)) {
+      throw new WsException('All players must be ready');
+    }
+  }
+
+  private setupPlayersAndDeck(room: GameRoom) {
+    const players = room.players.filter(p => p.role === 'PLAYER');
+
+    const deck = this.gameSetupService.createDeck();
+    this.gameSetupService.shuffle(deck);
+
+    const { updatedPlayers, remainingDeck } =
+      this.gameSetupService.distributeCards(deck, players, 7);
+
+    return { updatedPlayers, remainingDeck };
+  }
+
+  private selectFirstCard(deck: Card[]): Card {
+    const maxAttempts = deck.length;
+
+    for (let i = 0; i < maxAttempts; i++) {
+      const card = deck.shift()!;
+      if (card.type === CardType.NUMBER) {
+        return card;
+      }
+      deck.push(card);
+    }
+
+    throw new WsException('Failed to find valid starting card');
+  }
+
+  private initializeGameState(
+    room: GameRoom,
+    updatedPlayers: Player[],
+    remainingDeck: Card[],
+    firstCard: Card
+  ) {
+    // players merge
+    room.players = room.players.map(p => {
+      const updated = updatedPlayers.find(up => up.userId === p.userId);
+      return updated ?? p;
+    });
+
+    this.initDiscardPile(room, firstCard);
+    room.drawPile = remainingDeck;
+
+    room.status = 'PLAYING';
+
+    const activePlayers = room.players.filter(
+      p => p.role === 'PLAYER' && !p.isOut
+    );
+
+    const randomIndex = Math.floor(Math.random() * activePlayers.length);
+    room.turnOwner = activePlayers[randomIndex].userId;
+
+    room.direction = GameDirection.CLOCKWISE;
+    room.attackStack = 0;
+    room.currentPower = 0;
+    room.lastActionId = 0;
+  }
+
+  private initDiscardPile(room: GameRoom, card: Card) {
+    room.discardPile = [card];
+    room.lastCard = card;
+  }
+
+  private pushToDiscardPile(room: GameRoom, card: Card) {
+    room.discardPile.push(card);
+    room.lastCard = card;
+  }
+
+}  

--- a/src/modules/socket/game.gateway.ts
+++ b/src/modules/socket/game.gateway.ts
@@ -17,6 +17,7 @@ import { SocketAuthMiddleware } from './middlewares/auth.middleware';
 import { WsExceptionFilter } from 'src/common/filters/ws-exception.filter';
 import { AuthService } from '../auth/auth.service';
 import { RoomService } from './room.service';
+import { GameService } from '../game/game.service';
 
 // 기본 ValidationPipe는 HTTP 예외를 던지므로, WebSocket에 맞게 커스텀 설정
 export const SocketValidationConfig = new ValidationPipe({
@@ -40,7 +41,8 @@ export class GameGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
 
   constructor(
     private readonly authService: AuthService,
-    private readonly roomService: RoomService
+    private readonly roomService: RoomService,
+    private readonly gameService: GameService,
   ) {}
 
   @SubscribeMessage(SocketEvent.CREATE_ROOM)
@@ -174,5 +176,16 @@ export class GameGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
     }
 
     client.emit(SocketEvent.IDENTITY, identityData); // 클라이언트에게 유저 정보 전달
+  }
+
+  @SubscribeMessage(SocketEvent.GAME_START)
+  handleGameStart(
+    @ConnectedSocket() client: Socket,
+  ) {
+    const user = client.data.user;
+    this.logger.log(`[${SocketEvent.GAME_START}] 유저 ${client.data.user.nickname}(${client.data.user.userId})가 게임 시작 시도`);
+    const updatedRoom = this.gameService.startGame(user.userId);
+
+    this.server.to(updatedRoom.roomId).emit(SocketEvent.GAME_STARTED, updatedRoom);
   }
 }

--- a/src/modules/socket/game.module.ts
+++ b/src/modules/socket/game.module.ts
@@ -3,12 +3,14 @@ import { AuthModule } from "../auth/auth.module";
 import { GameGateway } from "./game.gateway";
 import { RoomService } from "./room.service";
 import { GameSetupService } from "../game/game-setup.service";
+import { GameService } from "../game/game.service";
 
 @Module({
   imports: [AuthModule],
   providers: [
     GameGateway,
     RoomService,
+    GameService,
     GameSetupService
   ],
   exports: [],

--- a/src/modules/socket/room.service.ts
+++ b/src/modules/socket/room.service.ts
@@ -1,9 +1,11 @@
-import { GameRoom, Player } from 'src/shared/interfaces/game.interface';
-import { GameDirection } from 'src/shared/enums/game.enum';
+import { Card, GameRoom, Player } from 'src/shared/interfaces/game.interface';
+import { CardType, GameDirection } from 'src/shared/enums/game.enum';
 import { WsException } from '@nestjs/websockets';
 import { v4 as uuidv4 } from 'uuid';
 import { SocketData } from 'socket.io';
 import { Logger } from '@nestjs/common';
+import { LogType } from 'src/shared/enums/log.enum';
+import { GameLog } from 'src/shared/interfaces/log.interface';
 
 export class RoomService {
   // Key: roomId, Value: GameRoom
@@ -50,6 +52,8 @@ export class RoomService {
       attackStack: 0,
       currentPower: 0,
       lastCard: null,
+      drawPile: [],
+      discardPile: [],
       lastActionId: 0,
       turnOwner: null,
       isBonusTurn: false,
@@ -210,5 +214,25 @@ export class RoomService {
     player.isReady = !player.isReady;
 
     return room;
+  }
+
+  createSystemLog(room: GameRoom, actorId: string, type: LogType, message: string) {
+    const actor = room.players.find(p => p.userId === actorId);
+
+    return {
+      id: uuidv4(),
+      type,
+      actorId,
+      actorName: actor?.nickname ?? 'Unknown',
+      payload: { message },
+      timestamp: Date.now(),
+    };
+  }
+
+  pushLog(room: GameRoom, log: GameLog) {
+    room.recentLogs.push(log);
+    if (room.recentLogs.length > 5) {
+      room.recentLogs.shift();
+    }
   }
 }

--- a/src/shared/enums/socket-event.enum.ts
+++ b/src/shared/enums/socket-event.enum.ts
@@ -5,12 +5,14 @@ export enum SocketEvent {
   JOIN_ROOM = 'joinRoom',
   LEAVE_ROOM = 'leaveRoom',
   GAME_READY = 'gameReady',
+  GAME_START = 'gameStart',
   PLAY_CARD = 'playCard',
   DRAW_CARD = 'drawCard',
 
   // Server -> Client (Update/Response)
   IDENTITY = 'identity',
   GAME_STATE_UPDATE = 'gameStateUpdate',
+  GAME_STARTED = 'gameStarted',
   PLAYER_EFFECT = 'playerEffect',
   GAME_ERROR = 'gameError',
   GAME_OVER = 'gameOver',

--- a/src/shared/interfaces/game.interface.ts
+++ b/src/shared/interfaces/game.interface.ts
@@ -27,6 +27,8 @@ export interface GameRoom {
   attackStack: number;  // 누적된 벌칙 카드 수
   currentPower: number; // 마지막 칼 자루 수 (연쇄 공격을 얹기 위한 판정 기준)
   lastCard: Card | null; // 바닥에 놓인 카드
+  drawPile: Card[];     // 뽑기용 덱 (remainingDeck)
+  discardPile: Card[];  // 버린 카드 더미 (lastCard 포함)
   lastActionId: number; // 액션 검증용 counter (멱등성 보장)
   turnOwner: string | null;    // 현재 턴 유저 ID
   isBonusTurn: boolean; // "+" 카드 활성화 여부


### PR DESCRIPTION
## 📌 주요 작업 내용
* `GameService` 도입을 통해 `Gateway`의 비즈니스 로직을 분리하고 책임을 명확히 정의
* `startGame` 흐름을 **검증 → 카드 셋업 → 상태 초기화** 단계로 구조화
* 시작 카드 선택 시 `NUMBER` 타입만 허용하며, 덱 길이 기반의 반복 제한으로 시스템 안정성 확보
* `RoomService` 내 실시간 로그 생성(`createSystemLog`) 및 최근 로그(최대 5개) 관리 기능 추가(`pushLog`)
* `GameGateway`에 `GAME_START` 이벤트 핸들러 및 `GAME_STARTED` 브로드캐스트 로직 구현
* `game.service.spec.ts`를 통한 주요 게임 시작 시나리오 단위 테스트 완료

## 🧠 핵심 설계 포인트
1. **서비스 계층 분리 (Decoupling)**
   - `Gateway`는 소켓 이벤트 처리에 집중하고, 핵심 로직은 `GameService`로 위임하여 테스트 용이성 및 유지보수성 향상
2. **단계적 초기화 파이프라인**
   - `validate` → `setup` → `initialize`로 흐름을 분리하여 각 메서드의 단일 책임(SRP) 원칙 준수 및 가독성 확보
3. **방어적 시작 카드 선택 로직**
   - 게임 규칙상 `NUMBER` 카드만 시작 카드로 허용. 덱 전체 순회 후에도 미발견 시 예외 처리를 통해 무한 루프 방지
4. **로그 시스템 기반 마련 (ANI-13 연계)**
   - 메모리 내 최근 로그 관리 로직을 구현하여 유저 경험 개선. 향후 비동기 큐 기반의 영속 로그 시스템 확장을 고려한 인터페이스 설계
5. **테스트 주도 설계 (TDD) 및 검증**
   - **안정성 확보**: 게임 시작 조건(방장 권한, 최소 인원, 전원 Ready), 상태 변화, 카드 7장 분배 등 핵심 비즈니스 로직에 대해 15개 이상의 Unit Test를 선행 작성하여 리팩토링 및 기능 확장 시의 사이드 이펙트 방지
   - **Mocking 최적화**: `@golevelup/ts-jest`의 `createMock`을 활용하여 `RoomService`와 `GameSetupService` 의 의존성을 분리하고, 순수 비즈니스 로직 검증에 집중

## 🧪 테스트 결과 (Unit Tests)
<img width="554" height="373" alt="image" src="https://github.com/user-attachments/assets/7e79e883-d284-43c1-bd8f-a6813e9e1e78" />

## 📝 게임 시작 후 `gameStarted`이벤트를 수신한 클라이언트
<img width="498" height="503" alt="image" src="https://github.com/user-attachments/assets/422c7d88-39e4-4b29-b43b-58abb2f63e35" />

바닥 카드 설정과 방의 상태 초기화가 잘 됨.

<img width="448" height="274" alt="image" src="https://github.com/user-attachments/assets/e07b088b-997e-4a4b-b477-577f8c619933" />

각 플레이어에게 카드 7장 잘 분배됨

closes ANI-25