### PR TITLE
feat: [ANI-9] 클라이언트별 데이터 필터링용 Interceptor 구조 설계

### DIFF
--- a/src/modules/game/game.service.ts
+++ b/src/modules/game/game.service.ts
@@ -130,4 +130,8 @@ export class GameService {
     room.lastCard = card;
   }
 
+  getGameState(userId: string): GameRoom {
+    const room = this.getValidRoom(userId);
+    return room;
+  }
 }  

--- a/src/modules/game/game.service.ts
+++ b/src/modules/game/game.service.ts
@@ -41,6 +41,14 @@ export class GameService {
     const room = this.roomService.getRoom(roomId);
     if (!room) throw new WsException('Room not found');
 
+    const isParticipant = room.players.some(
+      (player) => player.userId === userId,
+    );
+
+    if (!isParticipant) {
+      throw new WsException('User is not a participant of this room');
+    }
+
     return room;
   }
 

--- a/src/modules/socket/dto/game-room.dto.ts
+++ b/src/modules/socket/dto/game-room.dto.ts
@@ -4,7 +4,7 @@ export class RoomIdDto {
   @IsUUID('4', { message: '방 ID는 유효한 UUID v4 형식이어야 합니다.' })
   @IsString()
   @IsNotEmpty()
-  roomId: string;
+  roomId!: string;
 }
 
 export class JoinRoomDto extends RoomIdDto {}
@@ -13,5 +13,5 @@ export class LeaveRoomDto extends RoomIdDto {}
 export class PlayCardDto extends RoomIdDto {
   @IsUUID('4', { message: '카드 ID는 유효한 UUID v4 형식이어야 합니다.' })
   @IsNotEmpty({ message: '낼 카드의 ID가 필요합니다.' })
-  cardId: string;
+  cardId!: string;
 }

--- a/src/modules/socket/dto/game-room.response.dto.spec.ts
+++ b/src/modules/socket/dto/game-room.response.dto.spec.ts
@@ -1,0 +1,55 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { GameRoomResponseDto } from './game-room.response.dto';
+import { CardSuit, CardType, GameDirection } from 'src/shared/enums/game.enum';
+import { GameRoom, Card } from 'src/shared/interfaces/game.interface';
+import { v4 as uuidv4 } from 'uuid';
+
+describe('GameRoomResponseDto', () => {
+
+  it('drawPile과 discardPile은 직렬화 시 제외되어야 한다', () => {
+    const room: GameRoom = {
+      roomId: 'room-1',
+      hostId: 'me',
+      attackStack: 0,
+      currentPower: 0,
+      lastCard: createMockCard(),
+      drawPile: [createMockCard()],
+      discardPile: [createMockCard()],
+      lastActionId: 0,
+      turnOwner: 'me',
+      isBonusTurn: false,
+      direction: GameDirection.CLOCKWISE,
+      status: 'PLAYING',
+      recentLogs: [],
+      players: [],
+    };
+
+    const dto = plainToInstance(GameRoomResponseDto, room, {
+      excludeExtraneousValues: true,
+    });
+
+    // 핵심 검증
+    expect((dto as any).drawPile).toBeUndefined();
+    expect((dto as any).discardPile).toBeUndefined();
+
+    // 추가적으로 안전하게 JSON 기준 검증
+    const serialized = JSON.parse(JSON.stringify(dto));
+
+    expect(serialized.drawPile).toBeUndefined();
+    expect(serialized.discardPile).toBeUndefined();
+  });
+
+});
+
+function createMockCard(overrides?: Partial<Card>): Card {
+  return {
+    id: uuidv4(),
+    suit: CardSuit.RABBIT,
+    type: CardType.NUMBER,
+    value: '1',
+    power: 0,
+    assetKey: 'rabbit_number_1',
+    ...overrides,
+  };
+}

--- a/src/modules/socket/dto/game-room.response.dto.ts
+++ b/src/modules/socket/dto/game-room.response.dto.ts
@@ -1,0 +1,60 @@
+import { Exclude, Expose, Type } from 'class-transformer';
+import { CardSuit, CardType, GameDirection } from 'src/shared/enums/game.enum';
+
+@Exclude()
+export class CardResponseDto {
+  @Expose() id!: string;
+  @Expose() suit!: CardSuit;
+  @Expose() type!: CardType;
+  @Expose() value!: string;
+  @Expose() power!: number;
+  @Expose() assetKey!: string;
+}
+
+@Exclude()
+export class PlayerResponseDto {
+  @Expose() userId!: string;
+  @Expose() nickname!: string;
+  @Expose() role!: 'PLAYER' | 'SPECTATOR';
+  @Expose() cardCount!: number;
+  @Expose() isOut!: boolean;
+  
+  @Expose()
+  @Type(() => CardResponseDto)
+  hand?: CardResponseDto[];
+}
+
+@Exclude()
+export class GameRoomResponseDto {
+  @Expose() roomId!: string;
+  @Expose() turnOwner!: string | null;
+  @Expose() isBonusTurn!: boolean;
+  @Expose() direction!: GameDirection;
+  @Expose() attackStack!: number;
+  @Expose()
+  @Type(() => GameLogResponseDto)
+  recentLogs!: GameLogResponseDto[];
+
+  @Expose()
+  @Type(() => PlayerResponseDto)
+  players!: PlayerResponseDto[];
+
+  @Expose()
+  @Type(() => CardResponseDto)
+  lastCard!: CardResponseDto | null;
+
+  // drawPile, discardPile 등은 
+  // @Expose()가 없으므로 자동으로 제외됩니다. (보안성 확보)
+}
+
+@Exclude()
+export class GameLogResponseDto {
+  @Expose() id!: string;
+  @Expose() type!: string;
+  @Expose() actorId!: string;
+  @Expose() actorName!: string;
+  @Expose() targetId?: string;
+  @Expose() cardId?: string;
+  @Expose() payload?: Record<string, unknown>;
+  @Expose() timestamp!: number;
+}

--- a/src/modules/socket/game.gateway.ts
+++ b/src/modules/socket/game.gateway.ts
@@ -9,7 +9,7 @@ import {
   MessageBody,
   WsException,
 } from '@nestjs/websockets';
-import { Logger, UseFilters, UsePipes, ValidationPipe } from '@nestjs/common';
+import { Logger, UseFilters, UseInterceptors, UsePipes, ValidationPipe } from '@nestjs/common';
 import { Server, Socket, SocketData } from 'socket.io';
 import { JoinRoomDto, LeaveRoomDto, PlayCardDto } from './dto/game-room.dto';
 import { SocketEvent } from 'src/shared/enums/socket-event.enum';
@@ -18,6 +18,7 @@ import { WsExceptionFilter } from 'src/common/filters/ws-exception.filter';
 import { AuthService } from '../auth/auth.service';
 import { RoomService } from './room.service';
 import { GameService } from '../game/game.service';
+import { GameResponseInterceptor } from './interceptors/game-response.interceptor';
 
 // 기본 ValidationPipe는 HTTP 예외를 던지므로, WebSocket에 맞게 커스텀 설정
 export const SocketValidationConfig = new ValidationPipe({
@@ -36,7 +37,7 @@ export const SocketValidationConfig = new ValidationPipe({
   cors: { origin: '*' }, // 개발 편의를 위한 CORS 허용
 })
 export class GameGateway implements OnGatewayInit, OnGatewayConnection, OnGatewayDisconnect {
-  @WebSocketServer() server: Server;
+  @WebSocketServer() server!: Server;
   private logger: Logger = new Logger('GameGateway');
 
   constructor(
@@ -178,6 +179,7 @@ export class GameGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
     client.emit(SocketEvent.IDENTITY, identityData); // 클라이언트에게 유저 정보 전달
   }
 
+  @UseInterceptors(GameResponseInterceptor)
   @SubscribeMessage(SocketEvent.GAME_START)
   handleGameStart(
     @ConnectedSocket() client: Socket,
@@ -186,6 +188,21 @@ export class GameGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
     this.logger.log(`[${SocketEvent.GAME_START}] 유저 ${client.data.user.nickname}(${client.data.user.userId})가 게임 시작 시도`);
     const updatedRoom = this.gameService.startGame(user.userId);
 
-    this.server.to(updatedRoom.roomId).emit(SocketEvent.GAME_STARTED, updatedRoom);
+    this.server.to(updatedRoom.roomId).emit(SocketEvent.GAME_STARTED);
+    return updatedRoom; // 인터셉터에서 마스킹 후 클라이언트에게 전달
+  }
+
+  @UseInterceptors(GameResponseInterceptor)
+  @SubscribeMessage(SocketEvent.GET_GAME_STATE)
+  handleGetGameState(
+    @ConnectedSocket() client: Socket,
+  ) {
+    const user = client.data.user;
+
+    this.logger.log(
+      `[${SocketEvent.GET_GAME_STATE}] 유저 ${user.nickname}(${user.userId})가 게임 상태 요청`,
+    );
+
+    return this.gameService.getGameState(user.userId);
   }
 }

--- a/src/modules/socket/game.module.ts
+++ b/src/modules/socket/game.module.ts
@@ -4,6 +4,8 @@ import { GameGateway } from "./game.gateway";
 import { RoomService } from "./room.service";
 import { GameSetupService } from "../game/game-setup.service";
 import { GameService } from "../game/game.service";
+import { MaskingService } from "./masking.service";
+import { GameResponseInterceptor } from "./interceptors/game-response.interceptor";
 
 @Module({
   imports: [AuthModule],
@@ -11,8 +13,10 @@ import { GameService } from "../game/game.service";
     GameGateway,
     RoomService,
     GameService,
-    GameSetupService
+    GameSetupService,
+    MaskingService,
+    GameResponseInterceptor
   ],
-  exports: [],
+  exports: [MaskingService],
 })
 export class GameModule {}

--- a/src/modules/socket/interceptors/game-response.interceptor.ts
+++ b/src/modules/socket/interceptors/game-response.interceptor.ts
@@ -1,0 +1,45 @@
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { plainToInstance } from 'class-transformer';
+import { GameRoomResponseDto } from '../dto/game-room.response.dto';
+import { MaskingService } from '../masking.service';
+
+@Injectable()
+export class GameResponseInterceptor implements NestInterceptor {
+
+  constructor(
+    private readonly maskingService: MaskingService,
+  ) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const client = context.switchToWs().getClient();
+    const user = client.data.user;
+
+    return next.handle().pipe(
+      map((data) => {
+        if (!data || !user) return data;
+
+        // 유저 기준 마스킹
+        const masked = this.maskingService.maskRoomForUser(
+          data,
+          user.userId,
+        );
+
+        return {
+          success: true,
+          data: plainToInstance(GameRoomResponseDto, masked, {
+            excludeExtraneousValues: true,
+            enableImplicitConversion: true,
+          }),
+          timestamp: Date.now(),
+        };
+      }),
+    );
+  }
+}

--- a/src/modules/socket/masking.service.spec.ts
+++ b/src/modules/socket/masking.service.spec.ts
@@ -1,0 +1,138 @@
+import { CardSuit, CardType, GameDirection } from "src/shared/enums/game.enum";
+import { Card, GameRoom } from "src/shared/interfaces/game.interface";
+import { v4 as uuidv4 } from 'uuid';
+import { MaskingService } from "./masking.service";
+
+describe('MaskingService', () => {
+  let service: MaskingService;
+
+  const meId = 'me';
+  const otherId = 'other';
+
+  let room: GameRoom;
+
+  beforeEach(() => {
+    service = new MaskingService();
+
+    room = {
+      roomId: 'room-1',
+      hostId: meId,
+      attackStack: 0,
+      currentPower: 0,
+      lastCard: null,
+      drawPile: [],
+      discardPile: [],
+      lastActionId: 0,
+      turnOwner: meId,
+      isBonusTurn: false,
+      direction: GameDirection.CLOCKWISE,
+      status: 'PLAYING',
+      recentLogs: [],
+      players: [
+        {
+          userId: meId,
+          nickname: 'me',
+          isGuest: true,
+          hand: Array.from({ length: 7 }, () => createMockCard()),
+          cardCount: 7,
+          isReady: true,
+          isOut: false,
+          role: 'PLAYER',
+        },
+        {
+          userId: otherId,
+          nickname: 'other',
+          isGuest: true,
+          hand: Array.from({ length: 7 }, () => createMockCard()),
+          cardCount: 7,
+          isReady: true,
+          isOut: false,
+          role: 'PLAYER',
+        },
+      ],
+    };
+  });
+
+  it('자신의 hand는 그대로 노출되어야 한다', () => {
+    const result = service.maskRoomForUser(room, meId);
+
+    const me = result.players.find(p => p.userId === meId);
+
+    expect(me?.hand.length).toBe(7);
+    expect(me?.hand).toEqual(room.players[0].hand);
+  });
+
+  it('다른 플레이어의 hand는 숨겨져야 한다', () => {
+    const result = service.maskRoomForUser(room, meId);
+
+    const other = result.players.find(p => p.userId === otherId);
+
+    expect(other?.hand).toEqual([]);
+  });
+
+  it('다른 플레이어의 cardCount는 유지되어야 한다', () => {
+    const result = service.maskRoomForUser(room, meId);
+
+    const other = result.players.find(p => p.userId === otherId);
+
+    expect(other?.cardCount).toBe(7);
+  });
+
+  it('원본 room 객체는 변경되지 않아야 한다 (불변성 보장)', () => {
+    const original = JSON.parse(JSON.stringify(room));
+
+    service.maskRoomForUser(room, meId);
+
+    expect(room).toEqual(original);
+  });
+
+  it('관전자는 모든 플레이어의 hand를 볼 수 없어야 한다', () => {
+    // 관전자 추가
+    room.players.push({
+      userId: 'spec', nickname: 'spec', isGuest: true,
+      hand: [], cardCount: 0, isReady: false, isOut: false, role: 'SPECTATOR',
+    });
+
+    const result = service.maskRoomForUser(room, 'spec');
+    
+    // 관전자를 제외한 실제 플레이어들 추출
+    const players = result.players.filter(p => p.role === 'PLAYER');
+
+    // 모든 플레이어의 패가 비어있는지 전수 조사
+    players.forEach(player => {
+      expect(player.hand).toEqual([]);
+    });
+  });
+
+  it('자신이 관전자일 경우 자신의 hand도 볼 수 없어야 한다', () => {
+    // 관전자 추가
+    room.players.push({
+      userId: 'spec',
+      nickname: 'spec',
+      isGuest: true,
+      hand: Array.from({ length: 7 }, () => createMockCard()), // 일부러 넣어둠
+      cardCount: 7,
+      isReady: false,
+      isOut: false,
+      role: 'SPECTATOR',
+    });
+
+    const result = service.maskRoomForUser(room, 'spec');
+
+    const me = result.players.find(p => p.userId === 'spec');
+
+    expect(me?.hand).toEqual([]);
+  });
+});
+
+function createMockCard(overrides?: Partial<Card>): Card {
+  return {
+    id: uuidv4(),
+    suit: CardSuit.RABBIT,
+    type: CardType.NUMBER,
+    value: '1',
+    power: 0,
+    assetKey: 'rabbit_number_1',
+    ...overrides,
+  };
+}

--- a/src/modules/socket/masking.service.ts
+++ b/src/modules/socket/masking.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+import { GameRoom } from 'src/shared/interfaces/game.interface';
+
+@Injectable()
+export class MaskingService {
+
+  maskRoomForUser(room: GameRoom, userId: string): GameRoom {
+    return {
+      ...room,
+      players: room.players.map(player => {
+        const isMe = player.userId === userId;
+        const isSpectator = player.role === 'SPECTATOR';
+
+        // 관전자거나, 다른 플레이어면 hand 숨김
+        if (isSpectator || !isMe) {
+          return {
+            ...player,
+            hand: [],
+          };
+        }
+
+        // 나 자신이면 그대로
+        return { ...player };
+      }),
+    };
+  }
+}

--- a/src/modules/socket/middlewares/auth.middleware.ts
+++ b/src/modules/socket/middlewares/auth.middleware.ts
@@ -61,9 +61,11 @@ export const SocketAuthMiddleware = (authService: AuthService): SocketMiddleware
 
       next();
     } catch (error) {
-      const authError = new Error('Authentication Failed');
-      (authError as any).data = { code: 'AUTH_ERROR', message: error.message };
-      next(authError);
+      if (error instanceof Error) {
+        const authError = new Error('Authentication Failed');
+        (authError as any).data = { code: 'AUTH_ERROR', message: error.message };
+        next(authError);
+      }
     }
   };
 };

--- a/src/modules/socket/room.service.ts
+++ b/src/modules/socket/room.service.ts
@@ -38,7 +38,9 @@ export class RoomService {
     const roomId = uuidv4();
 
     const hostPlayer: Player = {
-      ...user,
+      userId: user.userId,
+      nickname: user.nickname,
+      isGuest: user.isGuest,
       hand: [],
       cardCount: 0,
       isReady: true, // 방장은 기본 준비 상태
@@ -86,11 +88,13 @@ export class RoomService {
     const role: Player['role'] = isPlaying ? 'SPECTATOR' : 'PLAYER';
 
     const newPlayer: Player = {
-      ...user,
-      isOut: false,
+      userId: user.userId,
+      nickname: user.nickname,
+      isGuest: user.isGuest,
       hand: [],
       cardCount: 0,
       isReady: false,
+      isOut: false,
       role,
     };
 

--- a/src/shared/enums/socket-event.enum.ts
+++ b/src/shared/enums/socket-event.enum.ts
@@ -1,6 +1,7 @@
 export enum SocketEvent {
   // Client -> Server (Action)
   CLIENT_READY = 'clientReady',
+  GET_GAME_STATE = 'getGameState',
   CREATE_ROOM = 'createRoom',
   JOIN_ROOM = 'joinRoom',
   LEAVE_ROOM = 'leaveRoom',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["jest", "node"],
     "module": "nodenext",
     "moduleResolution": "nodenext",
     "resolvePackageJsonExports": true,
@@ -13,7 +14,10 @@
     "target": "ES2023",
     "sourceMap": true,
     "outDir": "./dist",
-    "baseUrl": "./",
+    "baseUrl": ".",
+    "paths": {
+      "src/*": ["./src/*"]
+    },
     "incremental": true,
     "skipLibCheck": true,
     "strictNullChecks": true,


### PR DESCRIPTION
## 📝 작업 개요
게임 엔진의 원본 데이터(`GameRoom`)가 클라이언트에게 그대로 노출되던 보안 취약점을 해결하고, 유저별(플레이어/관전자) 시점에 맞춘 **데이터 마스킹(Masking) 및 DTO 직렬화 구조**를 도입했습니다.

## 🚀 주요 작업 내용

### 1. 보안 마스킹 서비스 (`MaskingService`) 도입
* **유저 시점별 필터링**: 요청한 유저가 본인이 아닐 경우 `hand`(패) 정보를 빈 배열(`[]`)로 마스킹 처리.
* **관전자 모드 대응**: `SPECTATOR` 역할의 유저에게는 모든 플레이어의 패를 숨기도록 로직 구현.
* **불변성 유지**: 원본 게임 객체를 훼손하지 않도록 전개 연산자(`...`)를 활용한 순수 함수 형태로 설계.

### 2. NestJS 인터셉터 기반의 자동 변환 (`GameResponseInterceptor`)
* 처리 흐름: 
`GameRoom` → `MaskingService` → DTO 변환 → Client 응답
* **관심사 분리**: 게이트웨이 로직 수정 없이 응답 직전에 마스킹 및 DTO 변환을 수행하도록 인터셉터 계층 구현.
* **통일된 응답 포맷**: GameRoom 상태 변화 응답을 `{ success: true, data: T, timestamp: number }` 구조로 래핑하여 프론트엔드 일관성 확보.

### 3. 직렬화 전용 DTO 설계 (`GameRoomResponseDto`)
* `class-transformer` 기반 `@Exclude` / `@Expose` 적용
* 민감 정보 자동 제거:
  * drawPile
  * discardPile
* 주요 DTO:
  * `GameRoomResponseDto`
  * `PlayerResponseDto`
  * `CardResponseDto`
  * `GameLogResponseDto`
* **순환 참조 방지**: `class-transformer`를 통해 중첩 객체(`players`, `lastCard`)까지 안정적으로 직렬화.

### 4. Game 상태 조회 API 추가
* `GET_GAME_STATE` 이벤트 신규 정의
* `GameService.getGameState(userId)` 추가
* Gateway에서 상태 조회 전용 메소드 분리

### 5. Gateway 구조 개선
* emit 기반 구조 → emit + return 혼합 구조로 개선
  * emit: 이벤트 알림
  * return: 요청자 데이터 응답
* `GAME_START`
  * 전체 알림: `emit`
  * 요청자 응답: `return`
* `GET_GAME_STATE`
  * 상태 조회 전용 Query

### 6. 인프라 및 기타 개선
* **Path Alias 설정**: `tsconfig.json`에 `src/*` 경로 별칭을 추가하여 절대 경로 임포트 지원.
* **안정성 강화**: `PlayCardDto` 등 핵심 DTO의 엄격한 타입 체크를 위한 `!` 연산자 및 `types` 설정 보강.
* Socket Auth Middleware 에러 처리 안정성 개선
* `RoomService`에서 불필요한 spread 제거 (명시적 필드 할당)

## 🎯 핵심 설계 포인트

### 1. 책임 분리 (Separation of Concerns)

| 영역 | 역할 |
| :--- | :--- |
| **Service** | 순수 비즈니스/도메인 로직 수행 |
| **MaskingService** | 유저 권한/역할에 따른 데이터 가공 (Filter) |
| **Interceptor** | 최종 응답 변환 및 규격화 (Formatting) |
| **DTO** | 외부 노출 필드 제어 (Security) |

### 2. 마스킹 vs 직렬화 분리
두 책임을 명확히 분리하여 유지보수성과 테스트 용이성을 확보했습니다.
* **MaskingService**: "유저마다 달라지는 데이터" (예: 내 패는 보이고, 상대 패는 숨김)
* **DTO**: "항상 숨겨야 하는 필드" (예: `drawPile`, `discardPile` 등 시스템 내부 데이터)
> 👉 **결과**: 비즈니스 로직 수정 없이 노출 정책만 독립적으로 변경 가능합니다.

---

### 3. WebSocket 응답 패턴 개선
기존의 단순 브로드캐스트 방식에서 **상태 동기화 패턴**으로 고도화했습니다.

* **기존**: `emit` 중심의 Push 방식 (전체 데이터를 매번 전송)
* **개선**: `emit` (알림) + `return` (데이터 응답) 기반의 **Pull-based State Sync**
    * **Event Notification**: "상태가 변했다"는 사실만 최소한으로 알림
    * **GET_GAME_STATE**: 클라이언트가 필요한 시점에 인터셉터를 거친 최신 상태를 직접 조회

---

### 4. Interceptor 활용
* WebSocket 환경에서도 HTTP와 동일한 응답 파이프라인을 구축했습니다.
* 공통 응답 포맷(`success`, `data`, `timestamp`) 및 DTO 변환 로직을 중앙화하여 코드 중복을 제거했습니다.

### 5. 테스트 주도 개발(TDD)
* `MaskingService`와 `ResponseDto`에 대한 단위 테스트를 작성하여 마스킹 누락이 없음을 검증했습니다.

## ✅ 테스트 결과
* **Unit Test**: `masking.service.spec.ts`, `game-room.response.dto.spec.ts` 통과 (100%).  
  <img width="634" height="152" alt="image" src="https://github.com/user-attachments/assets/2bd84c8b-763b-420d-a6af-7d9a0e492397" />
  <img width="586" height="222" alt="image" src="https://github.com/user-attachments/assets/e5bbe099-934c-4361-aab1-e3a72844b3c7" />


* **E2E Test**: Postman을 통한 실제 소켓 이벤트(`gameStart`, `getGameState`) 송수신 및 마스킹 데이터 확인 완료.
  * 방장이 게임 시작시 방 참가자 모두에게 `gameStarted` 이벤트 전송
    * Guest_63da (방장)
      <img width="797" height="77" alt="image" src="https://github.com/user-attachments/assets/ae6cc41a-9ef0-4fbd-8749-12dc675266c2" />
    * Guest_d5d6
      <img width="801" height="43" alt="image" src="https://github.com/user-attachments/assets/daa87f54-6168-45a6-b88c-648f95af08f5" />
  * 클라이언트에서 `getGameState` 전송시 각 요청자에게 상대방의 패 등이 마스킹된 정보 수신
    * Guest_63da (방장)이 전송시
      <img width="500" height="422" alt="image" src="https://github.com/user-attachments/assets/20bb2919-4f9f-42cb-aead-b5f9a25bad7d" />
      본인 패는 보임
      <img width="446" height="146" alt="image" src="https://github.com/user-attachments/assets/dda16ef5-38c5-4f49-8eb7-91a4cff136c2" />
      상대방 패는 가려짐

closes ANI-9