### PR TITLE
feat: [ANI-27] 권한 검증 Guard

### DIFF
--- a/src/common/guards/game-participant.guard.ts
+++ b/src/common/guards/game-participant.guard.ts
@@ -1,0 +1,59 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  Logger,
+} from '@nestjs/common';
+import { WsException } from '@nestjs/websockets';
+import { SocketData } from 'socket.io';
+import { RoomService } from 'src/modules/socket/room.service';
+
+@Injectable()
+export class GameParticipantGuard implements CanActivate {
+  private readonly logger = new Logger(GameParticipantGuard.name);
+
+  constructor(
+    private readonly roomService: RoomService,
+  ) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const client = context.switchToWs().getClient();
+    const user: SocketData['user'] = client.data.user;
+
+    // 인증 체크
+    if (!user) {
+      this.logger.warn('[Guard] Unauthorized access');
+      throw new WsException('Unauthorized');
+    }
+
+    // 유저가 속한 방 조회 (서버 기준)
+    const roomId = this.roomService.getUserRoom(user.userId);
+    if (!roomId) {
+      this.logger.warn(`[Guard] User ${user.userId} is not in any room`);
+      throw new WsException('User is not in any room');
+    }
+
+    // 방 존재 여부
+    const room = this.roomService.getRoom(roomId);
+    if (!room) {
+      this.logger.warn(`[Guard] Room ${roomId} not found`);
+      throw new WsException('Room not found');
+    }
+
+    // 실제 참여자 검증
+    const isParticipant = room.players.some(
+      (p) => p.userId === user.userId,
+    );
+
+    if (!isParticipant) {
+      this.logger.warn(
+        `[Guard] User ${user.userId} is not a participant of room ${roomId}`,
+      );
+      throw new WsException('User is not a participant');
+    }
+
+    client.data.room = room;
+
+    return true;
+  }
+}

--- a/src/common/guards/member-only.guard.ts
+++ b/src/common/guards/member-only.guard.ts
@@ -1,0 +1,34 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  Logger,
+} from '@nestjs/common';
+import { WsException } from '@nestjs/websockets';
+import { SocketData } from 'socket.io';
+
+@Injectable()
+export class MemberOnlyGuard implements CanActivate {
+  private readonly logger = new Logger(MemberOnlyGuard.name);
+
+  canActivate(context: ExecutionContext): boolean {
+    const client = context.switchToWs().getClient();
+    const user: SocketData['user'] = client.data.user;
+
+    // 인증 체크
+    if (!user) {
+      this.logger.warn('[Guard] Unauthorized access');
+      throw new WsException('Unauthorized');
+    }
+
+    // 회원 여부 체크
+    if (user.isGuest) {
+      this.logger.warn(
+        `[Guard] Guest user ${user.userId} tried to access member-only action`,
+      );
+      throw new WsException('Only registered users can perform this action');
+    }
+
+    return true;
+  }
+}

--- a/src/common/guards/room-master.guard.ts
+++ b/src/common/guards/room-master.guard.ts
@@ -1,0 +1,35 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  Logger,
+} from '@nestjs/common';
+import { WsException } from '@nestjs/websockets';
+import { RoomService } from 'src/modules/socket/room.service';
+import { SocketData } from 'socket.io';
+
+@Injectable()
+export class RoomMasterGuard implements CanActivate {
+  private readonly logger = new Logger(RoomMasterGuard.name);
+
+  constructor(
+    private readonly roomService: RoomService,
+  ) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const client = context.switchToWs().getClient();
+    const user: SocketData['user'] = client.data.user;
+
+    // ParticipantGuard 이후라 가정 → 최소 체크만 수행
+    const room = client.data.room;
+
+    if (room!.hostId !== user.userId) {
+      this.logger.warn(
+        `[RoomMasterGuard] User ${user.userId} is not host of room ${room!.roomId}`,
+      );
+      throw new WsException('Only host can perform this action');
+    }
+
+    return true;
+  }
+}

--- a/src/common/guards/turnowner.guard.ts
+++ b/src/common/guards/turnowner.guard.ts
@@ -1,0 +1,35 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  Logger,
+} from '@nestjs/common';
+import { WsException } from '@nestjs/websockets';
+import { SocketData } from 'socket.io';
+import { RoomService } from 'src/modules/socket/room.service';
+
+@Injectable()
+export class TurnOwnerGuard implements CanActivate {
+  private readonly logger = new Logger(TurnOwnerGuard.name);
+
+  constructor(
+    private readonly roomService: RoomService,
+  ) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const client = context.switchToWs().getClient();
+    const user = client.data.user;
+
+    // ParticipantGuard 이후라 가정 → 최소 체크만 수행
+    const room = client.data.room;
+
+    if (room!.turnOwner !== user.userId) {
+      this.logger.warn(
+        `[TurnOwnerGuard] User ${user.userId} is not turn owner`,
+      );
+      throw new WsException('Not your turn');
+    }
+
+    return true;
+  }
+}

--- a/src/modules/socket/dto/game-room.dto.ts
+++ b/src/modules/socket/dto/game-room.dto.ts
@@ -8,7 +8,6 @@ export class RoomIdDto {
 }
 
 export class JoinRoomDto extends RoomIdDto {}
-export class LeaveRoomDto extends RoomIdDto {}
 
 export class PlayCardDto extends RoomIdDto {
   @IsUUID('4', { message: '카드 ID는 유효한 UUID v4 형식이어야 합니다.' })

--- a/src/modules/socket/game.gateway.ts
+++ b/src/modules/socket/game.gateway.ts
@@ -103,6 +103,8 @@ export class GameGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
     });
 
     client.leave(roomId);
+
+    delete client.data.room; // 클라이언트의 소켓 데이터에서 방 정보 제거
   }
 
   // 준비 상태 변경

--- a/src/modules/socket/game.gateway.ts
+++ b/src/modules/socket/game.gateway.ts
@@ -9,9 +9,9 @@ import {
   MessageBody,
   WsException,
 } from '@nestjs/websockets';
-import { Logger, UseFilters, UseInterceptors, UsePipes, ValidationPipe } from '@nestjs/common';
+import { Logger, UseFilters, UseGuards, UseInterceptors, UsePipes, ValidationPipe } from '@nestjs/common';
 import { Server, Socket, SocketData } from 'socket.io';
-import { JoinRoomDto, LeaveRoomDto, PlayCardDto } from './dto/game-room.dto';
+import { JoinRoomDto, PlayCardDto } from './dto/game-room.dto';
 import { SocketEvent } from 'src/shared/enums/socket-event.enum';
 import { SocketAuthMiddleware } from './middlewares/auth.middleware';
 import { WsExceptionFilter } from 'src/common/filters/ws-exception.filter';
@@ -19,6 +19,10 @@ import { AuthService } from '../auth/auth.service';
 import { RoomService } from './room.service';
 import { GameService } from '../game/game.service';
 import { GameResponseInterceptor } from './interceptors/game-response.interceptor';
+import { GameParticipantGuard } from 'src/common/guards/game-participant.guard';
+import { TurnOwnerGuard } from 'src/common/guards/turnowner.guard';
+import { RoomMasterGuard } from 'src/common/guards/room-master.guard';
+import { MemberOnlyGuard } from 'src/common/guards/member-only.guard';
 
 // 기본 ValidationPipe는 HTTP 예외를 던지므로, WebSocket에 맞게 커스텀 설정
 export const SocketValidationConfig = new ValidationPipe({
@@ -46,6 +50,7 @@ export class GameGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
     private readonly gameService: GameService,
   ) {}
 
+  @UseGuards(MemberOnlyGuard)
   @SubscribeMessage(SocketEvent.CREATE_ROOM)
   handleCreateRoom(
     @ConnectedSocket() client: Socket,
@@ -81,10 +86,10 @@ export class GameGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
   }
 
   // 방 퇴장 (leaveRoom)
+  @UseGuards(GameParticipantGuard)
   @SubscribeMessage(SocketEvent.LEAVE_ROOM)
   handleLeaveRoom(
     @ConnectedSocket() client: Socket,
-    @MessageBody() data: LeaveRoomDto,
   ) {
     const { room, roomId, isDeleted } = this.roomService.leaveRoom(client.data.user.userId);
 
@@ -92,7 +97,7 @@ export class GameGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
       return;
     }
 
-    this.logger.log(`[${SocketEvent.LEAVE_ROOM}] 유저 ${client.data.user.nickname}(${client.data.user.userId})가 방(${data.roomId}) 퇴장 시도`);
+    this.logger.log(`[${SocketEvent.LEAVE_ROOM}] 유저 ${client.data.user.nickname}(${client.data.user.userId})가 방(${roomId}) 퇴장 시도`);
     client.to(roomId).emit(SocketEvent.ROOM_UPDATED, {
       message: `${client.data.user.nickname}님이 퇴장하셨습니다. ${isDeleted ? '방이 삭제되었습니다.' : ''}`,
     });
@@ -101,6 +106,7 @@ export class GameGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
   }
 
   // 준비 상태 변경
+  @UseGuards(GameParticipantGuard)
   @SubscribeMessage(SocketEvent.GAME_READY)
   handleGameReady(
     @ConnectedSocket() client: Socket,
@@ -117,6 +123,7 @@ export class GameGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
   }
 
   // 카드 내기 (playCard)
+  @UseGuards(GameParticipantGuard, TurnOwnerGuard)
   @SubscribeMessage(SocketEvent.PLAY_CARD)
   handlePlayCard(
     @ConnectedSocket() client: Socket,
@@ -177,6 +184,7 @@ export class GameGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
     client.emit(SocketEvent.IDENTITY, identityData); // 클라이언트에게 유저 정보 전달
   }
 
+  @UseGuards(GameParticipantGuard, RoomMasterGuard)
   @UseInterceptors(GameResponseInterceptor)
   @SubscribeMessage(SocketEvent.GAME_START)
   handleGameStart(
@@ -190,6 +198,7 @@ export class GameGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
     return updatedRoom; // 인터셉터에서 마스킹 후 클라이언트에게 전달
   }
 
+  @UseGuards(GameParticipantGuard)
   @UseInterceptors(GameResponseInterceptor)
   @SubscribeMessage(SocketEvent.GET_GAME_STATE)
   handleGetGameState(

--- a/src/shared/interfaces/socket-data.interface.ts
+++ b/src/shared/interfaces/socket-data.interface.ts
@@ -1,4 +1,5 @@
 import 'socket.io';
+import { GameRoom } from './game.interface';
 declare module 'socket.io' {
   export interface SocketData {
     user: {
@@ -7,5 +8,6 @@ declare module 'socket.io' {
       isGuest: boolean;
       accessToken?: string;
     };
+    room: GameRoom;
   }
 }


### PR DESCRIPTION
## 📌 주요 작업 내용

* WebSocket 기반 권한 검증을 위해 `GameParticipantGuard`, `RoomMasterGuard`, `TurnOwnerGuard`, `MemberOnlyGuard` 신규 도입
* `GameParticipantGuard`에서 방 참여 여부를 검증하고, `client.data.room`에 주입하여 Guard 간 컨텍스트 공유 구조 확립
* 방 생성 이벤트(`CREATE_ROOM`)에 회원 전용 정책 적용 (`MemberOnlyGuard`)
* 게임 시작, 카드 제출 등 주요 이벤트에 역할 기반 Guard 체인 적용으로 책임 분리 강화
* `LeaveRoomDto` 제거 및 서버 기준 방 식별 방식으로 변경하여 클라이언트 의존도 축소
* `SocketData`에 `room` 필드 확장하여 요청 단위 캐시 형태의 데이터 전달 구조 도입

---

## 🧠 핵심 설계 포인트

### 1. **Guard 체인 기반 권한 검증 구조**

* 이벤트별로 필요한 Guard를 조합하여 적용 (`Participant → Role → Turn`)
* 단일 Guard에 로직 집중을 피하고, 책임을 분리하여 재사용성과 가독성 확보

---

### 2. **서버 기준 상태 검증 (Trust Server Over Client)**

* `roomId`를 클라이언트 입력이 아닌 서버의 `getUserRoom`을 통해 조회
* 클라이언트 변조 가능성을 원천 차단하고, 서버를 단일 신뢰 소스로 유지

---

### 3. **Guard 간 컨텍스트 공유 최적화**

* `GameParticipantGuard`에서 조회한 `room`을 `client.data`에 주입
* 이후 Guard(`RoomMasterGuard`, `TurnOwnerGuard`)에서 재조회 없이 활용
* 중복 조회 제거를 통한 성능 최적화 및 코드 단순화

---

### 4. **정책과 권한의 분리**

* `MemberOnlyGuard`를 통해 “회원 전용 기능(방 생성)”을 명확히 분리
* 인증/참여/역할/턴을 각각 독립적인 Guard로 설계하여 확장성 확보

---

### 5. **클라이언트 의존도 제거 및 인터페이스 정리**

* `LeaveRoomDto` 제거 → 서버 상태 기반으로만 방 퇴장 처리
* 잘못된 입력 가능성 제거 및 API 일관성 향상

---

### 6. **요청 단위 캐시(Request Context) 도입**

* `client.data.room`을 상태 저장소가 아닌 “요청 컨텍스트 캐시”로 활용
* Guard → Handler → Interceptor까지 동일 데이터 흐름 유지
* Service 계층은 여전히 `RoomService`를 단일 Source of Truth로 사용

---


closes ANI-27, ANI-26
resolves #23