### PR TITLE
feat: [ANI-10] 게임 액션(Action)별 유효성 검사 추상 인터페이스 정의

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+AGENTS.md
+
 # compiled output
 /dist
 /node_modules

--- a/src/modules/game/validators/abstract-special-card.validator.spec.ts
+++ b/src/modules/game/validators/abstract-special-card.validator.spec.ts
@@ -1,0 +1,188 @@
+import { WsException } from '@nestjs/websockets';
+
+import {
+  CardSuit,
+  CardType,
+} from 'src/shared/enums/game.enum';
+import {
+  Card,
+  GameRoom,
+} from 'src/shared/interfaces/game.interface';
+
+import {
+  AbstractSpecialCardValidator,
+  SpecialCardRuleContext,
+} from './abstract-special-card.validator';
+import { createSpecialValidatorFixtures } from './special-card-validator.spec.fixture';
+
+describe('AbstractSpecialCardValidator', () => {
+  class TestSpecialValidator extends AbstractSpecialCardValidator {
+    protected readonly specialValue = 'TEST_SPECIAL';
+
+    attackStackCalled = 0;
+    noAttackStackCalled = 0;
+    canPlayInAttackStack = true;
+    canPlayInNoAttackStack = true;
+
+    protected canPlayWhenAttackStack(
+      _ctx: SpecialCardRuleContext,
+    ): boolean {
+      this.attackStackCalled += 1;
+      return this.canPlayInAttackStack;
+    }
+
+    protected canPlayWhenNoAttackStack(
+      _ctx: SpecialCardRuleContext,
+    ): boolean {
+      this.noAttackStackCalled += 1;
+      return this.canPlayInNoAttackStack;
+    }
+
+    protected getInvalidPlayMessage(): string {
+      return 'Cannot play test special card in current state';
+    }
+  }
+
+  let validator: TestSpecialValidator;
+  const {
+    createMockCard,
+    createMockPlayer,
+    createMockRoom,
+  } = createSpecialValidatorFixtures(
+    'TEST_SPECIAL',
+    'rabbit_test_special',
+  );
+
+  beforeEach(() => {
+    validator = new TestSpecialValidator();
+  });
+
+  describe('supports', () => {
+    it('SPECIAL + specialValue일 때만 true여야 한다', () => {
+      expect(
+        validator.supports(createMockCard()),
+      ).toBe(true);
+
+      expect(
+        validator.supports(createMockCard({
+          value: 'BONUS',
+        })),
+      ).toBe(false);
+
+      expect(
+        validator.supports(createMockCard({
+          type: CardType.NUMBER,
+          value: '7',
+        })),
+      ).toBe(false);
+    });
+  });
+
+  describe('validate', () => {
+    it('lastCard가 없으면 실패해야 한다', () => {
+      const card = createMockCard({
+        id: 'card-2',
+      });
+      const player = createMockPlayer({
+        hand: [card],
+      });
+      const room = createMockRoom({
+        lastCard: null,
+      });
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card,
+        }),
+      ).toThrow(WsException);
+    });
+
+    it('attackStack > 0이면 공격 스택 분기만 호출해야 한다', () => {
+      const card = createMockCard({
+        id: 'card-2',
+      });
+      const player = createMockPlayer({
+        hand: [card],
+      });
+      const room = createMockRoom({
+        attackStack: 2,
+        lastCard: createMockCard({
+          id: 'last-card',
+          suit: CardSuit.BEAR,
+          value: 'SWORD_2',
+          type: CardType.ATTACK,
+          power: 2,
+        }),
+      });
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card,
+        }),
+      ).not.toThrow();
+
+      expect(
+        validator.attackStackCalled,
+      ).toBe(1);
+      expect(
+        validator.noAttackStackCalled,
+      ).toBe(0);
+    });
+
+    it('attackStack === 0이면 비공격 분기만 호출해야 한다', () => {
+      const card = createMockCard({
+        id: 'card-2',
+      });
+      const player = createMockPlayer({
+        hand: [card],
+      });
+      const room = createMockRoom({
+        attackStack: 0,
+        lastCard: createMockCard({
+          id: 'last-card',
+          suit: CardSuit.BEAR,
+          value: '7',
+          type: CardType.NUMBER,
+        }),
+      });
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card,
+        }),
+      ).not.toThrow();
+
+      expect(
+        validator.attackStackCalled,
+      ).toBe(0);
+      expect(
+        validator.noAttackStackCalled,
+      ).toBe(1);
+    });
+
+    it('specialValue가 다르면 실패해야 한다', () => {
+      const card = createMockCard({
+        id: 'card-2',
+        value: 'SHIELD',
+      });
+      const player = createMockPlayer({
+        hand: [card],
+      });
+      const room = createMockRoom();
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card: card as Card,
+        }),
+      ).toThrow(WsException);
+    });
+  });
+});

--- a/src/modules/game/validators/abstract-special-card.validator.ts
+++ b/src/modules/game/validators/abstract-special-card.validator.ts
@@ -1,0 +1,85 @@
+import { WsException } from '@nestjs/websockets';
+
+import { CardType } from 'src/shared/enums/game.enum';
+import { Card } from 'src/shared/interfaces/game.interface';
+
+import {
+  CardActionValidator,
+  ValidateCardActionParams,
+} from './card-action.validator';
+
+export interface SpecialCardRuleContext {
+  room: ValidateCardActionParams['room'];
+  card: ValidateCardActionParams['card'];
+  lastCard: NonNullable<ValidateCardActionParams['room']['lastCard']>;
+}
+
+export abstract class AbstractSpecialCardValidator extends CardActionValidator {
+  protected abstract readonly specialValue: string;
+
+  supports(card: Card): boolean {
+    return (
+      card.type === CardType.SPECIAL &&
+      card.value === this.specialValue
+    );
+  }
+
+  protected validateRule(
+    params: ValidateCardActionParams,
+  ): void {
+    const { room, card } = params;
+
+    if (card.value !== this.specialValue) {
+      throw new WsException(
+        `This validator only supports ${this.specialValue} card`,
+      );
+    }
+
+    const lastCard = room.lastCard;
+
+    if (!lastCard) {
+      throw new WsException(
+        'Last card does not exist',
+      );
+    }
+
+    const ctx: SpecialCardRuleContext = {
+      room,
+      card,
+      lastCard,
+    };
+
+    const canPlay =
+      room.attackStack > 0
+        ? this.canPlayWhenAttackStack(ctx)
+        : this.canPlayWhenNoAttackStack(ctx);
+
+    if (!canPlay) {
+      throw new WsException(
+        this.getInvalidPlayMessage(),
+      );
+    }
+  }
+
+  protected isSameSuit(
+    ctx: SpecialCardRuleContext,
+  ): boolean {
+    return ctx.lastCard.suit === ctx.card.suit;
+  }
+
+  protected isSameValue(
+    ctx: SpecialCardRuleContext,
+  ): boolean {
+    return ctx.lastCard.value === ctx.card.value;
+  }
+
+  protected abstract canPlayWhenAttackStack(
+    ctx: SpecialCardRuleContext,
+  ): boolean;
+
+  protected abstract canPlayWhenNoAttackStack(
+    ctx: SpecialCardRuleContext,
+  ): boolean;
+
+  protected abstract getInvalidPlayMessage(): string;
+}

--- a/src/modules/game/validators/action-validator.interface.ts
+++ b/src/modules/game/validators/action-validator.interface.ts
@@ -1,0 +1,8 @@
+import { Card } from 'src/shared/interfaces/game.interface';
+
+import { ValidateCardActionParams } from './card-action.validator';
+
+export interface ActionValidator {
+  supports(card: Card): boolean;
+  validate(params: ValidateCardActionParams): void;
+}

--- a/src/modules/game/validators/action-validator.registry.spec.ts
+++ b/src/modules/game/validators/action-validator.registry.spec.ts
@@ -1,0 +1,98 @@
+import { WsException } from '@nestjs/websockets';
+
+import {
+  CardSuit,
+  CardType,
+} from 'src/shared/enums/game.enum';
+import { Card } from 'src/shared/interfaces/game.interface';
+
+import { ActionValidator } from './action-validator.interface';
+import { ActionValidatorRegistry } from './action-validator.registry';
+
+describe('ActionValidatorRegistry', () => {
+  const createMockCard = (
+    overrides: Partial<Card> = {},
+  ): Card => ({
+    id: 'card-1',
+    suit: CardSuit.RABBIT,
+    value: 'JUMP',
+    type: CardType.SPECIAL,
+    power: 0,
+    assetKey: 'rabbit_jump',
+    ...overrides,
+  });
+
+  const createMockValidator = (
+    supportsValue: boolean,
+  ): ActionValidator => ({
+    supports: jest.fn().mockReturnValue(
+      supportsValue,
+    ),
+    validate: jest.fn(),
+  });
+
+  it('카드에 맞는 validator를 반환해야 한다', () => {
+    const first = createMockValidator(
+      false,
+    );
+    const second = createMockValidator(
+      true,
+    );
+
+    const registry =
+      new ActionValidatorRegistry([
+        first,
+        second,
+      ]);
+
+    const result = registry.getValidator(
+      createMockCard(),
+    );
+
+    expect(result).toBe(second);
+  });
+
+  it('일치하는 validator가 없으면 예외를 던져야 한다', () => {
+    const first = createMockValidator(
+      false,
+    );
+    const second = createMockValidator(
+      false,
+    );
+
+    const registry =
+      new ActionValidatorRegistry([
+        first,
+        second,
+      ]);
+
+    expect(() =>
+      registry.getValidator(
+        createMockCard({
+          value: 'UNKNOWN',
+        }),
+      ),
+    ).toThrow(WsException);
+  });
+
+  it('일치하는 validator가 2개 이상이면 예외를 던져야 한다', () => {
+    const first = createMockValidator(
+      true,
+    );
+    const second = createMockValidator(
+      true,
+    );
+
+    const registry =
+      new ActionValidatorRegistry([
+        first,
+        second,
+      ]);
+
+    expect(() =>
+      registry.getValidator(
+        createMockCard(),
+      ),
+    ).toThrow(WsException);
+  });
+});

--- a/src/modules/game/validators/action-validator.registry.ts
+++ b/src/modules/game/validators/action-validator.registry.ts
@@ -1,0 +1,35 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { WsException } from '@nestjs/websockets';
+
+import { Card } from 'src/shared/interfaces/game.interface';
+
+import { ActionValidator } from './action-validator.interface';
+import { ACTION_VALIDATORS } from './action-validator.token';
+
+@Injectable()
+export class ActionValidatorRegistry {
+  constructor(
+    @Inject(ACTION_VALIDATORS)
+    private readonly validators: ActionValidator[],
+  ) {}
+
+  getValidator(card: Card): ActionValidator {
+    const matchedValidators = this.validators.filter(
+      (candidate) => candidate.supports(card),
+    );
+
+    if (matchedValidators.length === 0) {
+      throw new WsException(
+        `No validator found for card: ${card.value}`,
+      );
+    }
+
+    if (matchedValidators.length > 1) {
+      throw new WsException(
+        `Multiple validators found for card: ${card.value}`,
+      );
+    }
+
+    return matchedValidators[0];
+  }
+}

--- a/src/modules/game/validators/action-validator.token.ts
+++ b/src/modules/game/validators/action-validator.token.ts
@@ -1,0 +1,3 @@
+export const ACTION_VALIDATORS = Symbol(
+  'ACTION_VALIDATORS',
+);

--- a/src/modules/game/validators/attack-card-action.validator.spec.ts
+++ b/src/modules/game/validators/attack-card-action.validator.spec.ts
@@ -1,0 +1,291 @@
+import { WsException } from '@nestjs/websockets';
+
+import {
+  CardSuit,
+  CardType,
+  GameDirection,
+} from 'src/shared/enums/game.enum';
+
+import {
+  Card,
+  GameRoom,
+  Player,
+} from 'src/shared/interfaces/game.interface';
+
+import { AttackCardValidator } from './attack-card-action.validator';
+
+describe('AttackCardValidator', () => {
+  let validator: AttackCardValidator;
+
+  beforeEach(() => {
+    validator = new AttackCardValidator();
+  });
+
+  const createMockCard = (
+    overrides: Partial<Card> = {},
+  ): Card => ({
+    id: 'card-1',
+    suit: CardSuit.RABBIT,
+    value: 'SWORD_2',
+    type: CardType.ATTACK,
+    power: 2,
+    assetKey: 'rabbit_sword_2',
+    ...overrides,
+  });
+
+  const createMockPlayer = (
+    overrides: Partial<Player> = {},
+  ): Player => ({
+    userId: 'user-1',
+    nickname: 'tester',
+    role: 'PLAYER',
+    isGuest: false,
+    isOut: false,
+    isReady: true,
+    cardCount: 1,
+    hand: [createMockCard()],
+    ...overrides,
+  });
+
+  const createMockRoom = (
+    overrides: Partial<GameRoom> = {},
+  ): Partial<GameRoom> => ({
+    roomId: 'room-1',
+    hostId: 'user-1',
+    status: 'PLAYING',
+    turnOwner: 'user-1',
+    direction: GameDirection.CLOCKWISE,
+    attackStack: 0,
+    isBonusTurn: false,
+    players: [],
+    lastCard: createMockCard({
+      id: 'last-card',
+      suit: CardSuit.RABBIT,
+      value: 'SWORD_2',
+      power: 2,
+    }),
+    ...overrides,
+  });
+
+  describe('validate', () => {
+    it('공격 체인이 아닐 때 같은 동물이면 성공해야 한다', () => {
+      const card = createMockCard({
+        id: 'card-2',
+        suit: CardSuit.RABBIT,
+        value: 'SWORD_3',
+        power: 3,
+      });
+
+      const player = createMockPlayer({
+        hand: [card],
+      });
+
+      const room = createMockRoom({
+        attackStack: 0,
+        lastCard: createMockCard({
+          suit: CardSuit.RABBIT,
+          value: '7',
+          power: 0,
+        }),
+      });
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card,
+        }),
+      ).not.toThrow();
+    });
+
+    it('공격 체인 중 현재 공격값 이상이면 성공해야 한다', () => {
+      const card = createMockCard({
+        id: 'card-4',
+        suit: CardSuit.BEAR, // 문양 달라도 가능
+        value: 'SWORD_3',
+        power: 3,
+      });
+
+      const player = createMockPlayer({
+        hand: [card],
+      });
+
+      const room = createMockRoom({
+        attackStack: 2,
+        lastCard: createMockCard({
+          suit: CardSuit.RABBIT,
+          value: 'SWORD_2',
+          power: 2,
+        }),
+      });
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card,
+        }),
+      ).not.toThrow();
+    });
+
+    it('공격 체인 중 현재 공격값보다 낮으면 실패해야 한다', () => {
+      const card = createMockCard({
+        id: 'card-2',
+        suit: CardSuit.BEAR,
+        value: 'SWORD_2',
+        power: 2,
+      });
+
+      const player = createMockPlayer({
+        hand: [card],
+      });
+
+      const room = createMockRoom({
+        attackStack: 3,
+        lastCard: createMockCard({
+          suit: CardSuit.RABBIT,
+          value: 'SWORD_3',
+          power: 3,
+        }),
+      });
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card,
+        }),
+      ).toThrow(WsException);
+    });
+
+    it('공격 체인이 아닐 때 동물모양이 다르면 실패해야 한다', () => {
+      const card = createMockCard({
+        id: 'card-2',
+        suit: CardSuit.BEAR,
+        value: 'SWORD_3',
+        power: 3,
+      });
+
+      const player = createMockPlayer({
+        hand: [card],
+      });
+
+      const room = createMockRoom({
+        attackStack: 0,
+        lastCard: createMockCard({
+          suit: CardSuit.RABBIT,
+          value: '4',
+          power: 0,
+        }),
+      });
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card,
+        }),
+      ).toThrow(WsException);
+    });
+
+    it('마지막 카드가 없으면 실패해야 한다', () => {
+      const card = createMockCard({
+        id: 'card-2',
+      });
+
+      const player = createMockPlayer({
+        hand: [card],
+      });
+
+      const room = createMockRoom({
+        lastCard: null,
+      });
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card,
+        }),
+      ).toThrow(WsException);
+    });
+
+    it('ATTACK 타입 카드만 지원해야 한다', () => {
+      expect(
+        validator.supports(createMockCard({
+          type: CardType.ATTACK,
+          value: 'SWORD_2',
+          power: 2,
+        })),
+      ).toBe(true);
+
+      expect(
+        validator.supports(createMockCard({
+          type: CardType.NUMBER,
+          value: '7',
+          power: 0,
+        })),
+      ).toBe(false);
+    });
+
+    it('공격 체인 중 같은 power도 허용되어야 한다', () => {
+      const card = createMockCard({
+        id: 'card-3',
+        suit: CardSuit.BEAR,
+        value: 'SWORD_3',
+        power: 3,
+      });
+
+      const player = createMockPlayer({
+        hand: [card],
+      });
+
+      const room = createMockRoom({
+        attackStack: 3,
+        lastCard: createMockCard({
+          suit: CardSuit.RABBIT,
+          value: 'SWORD_3',
+          power: 3,
+        }),
+      });
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card,
+        }),
+      ).not.toThrow();
+    });
+
+    it('공격 체인 중에는 문양이 같아도 현재 공격값보다 낮으면 실패해야 한다', () => {
+      const card = createMockCard({
+        id: 'card-2',
+        suit: CardSuit.RABBIT, // 문양은 같음
+        value: 'SWORD_2',
+        power: 2,
+      });
+
+      const player = createMockPlayer({
+        hand: [card],
+      });
+
+      const room = createMockRoom({
+        attackStack: 3,
+        lastCard: createMockCard({
+          suit: CardSuit.RABBIT,
+          value: 'SWORD_3',
+          power: 3,
+        }),
+      });
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card,
+        }),
+      ).toThrow(WsException);
+    });
+  });
+});

--- a/src/modules/game/validators/attack-card-action.validator.ts
+++ b/src/modules/game/validators/attack-card-action.validator.ts
@@ -1,0 +1,52 @@
+import { WsException } from '@nestjs/websockets';
+
+import { CardType } from 'src/shared/enums/game.enum';
+import { Card } from 'src/shared/interfaces/game.interface';
+
+import {
+  CardActionValidator,
+  ValidateCardActionParams,
+} from './card-action.validator';
+
+export class AttackCardValidator extends CardActionValidator {
+
+  supports(card: Card): boolean {
+    return card.type === CardType.ATTACK;
+  }
+
+  protected validateRule(
+    params: ValidateCardActionParams,
+  ): void {
+    const { room, card } = params;
+
+    const lastCard = room.lastCard;
+
+    if (!lastCard) {
+      throw new WsException(
+        'Last card does not exist',
+      );
+    }
+
+    // 공격 체인 상태
+    if (room.attackStack > 0) {
+      // 현재 공격값 이상만 가능
+      if (card.power < lastCard.power) {
+        throw new WsException(
+          'Attack card power is too low',
+        );
+      }
+
+      return;
+    }
+
+    // 일반 상태에서는 같은 문양만 허용
+    const isSameSuit =
+      card.suit === lastCard.suit;
+
+    if (!isSameSuit) {
+      throw new WsException(
+        'Attack card must match suit',
+      );
+    }
+  }
+}

--- a/src/modules/game/validators/base-action.validator.spec.ts
+++ b/src/modules/game/validators/base-action.validator.spec.ts
@@ -1,0 +1,139 @@
+import { WsException } from '@nestjs/websockets';
+
+import { CardSuit, CardType } from 'src/shared/enums/game.enum';
+
+import {
+  BaseActionValidator,
+  ValidateActionParams,
+} from './base-action.validator';
+import { Card, GameRoom, Player } from 'src/shared/interfaces/game.interface';
+
+describe('BaseActionValidator', () => {
+  class TestValidator extends BaseActionValidator {
+    supports(_card: Card): boolean {
+      return true;
+    }
+
+    protected validateRule(
+      params: ValidateActionParams,
+    ): void {
+      // 테스트용 no-op
+    }
+  }
+
+  let validator: TestValidator;
+
+  beforeEach(() => {
+    validator = new TestValidator();
+  });
+
+  const createMockCard = (overrides: Partial<Card> = {}) => ({
+    id: 'card-1',
+    suit: CardSuit.RABBIT,
+    value: '1',
+    type: CardType.NUMBER,
+    power: 0,
+    assetKey: 'rabbit_1',
+    ...overrides,
+  });
+
+  const createMockPlayer = (overrides: Partial<Player> = {}) => ({
+    userId: 'user-1',
+    nickname: 'tester',
+    role: 'PLAYER' as const,
+    isGuest: false,
+    isOut: false,
+    cardCount: 1,
+    isReady: true,
+    hand: [createMockCard()],
+    ...overrides,
+  });
+
+  const createMockRoom = (overrides: Partial<GameRoom> = {}) => ({
+    roomId: 'room-1',
+    status: 'PLAYING',
+    turnOwner: 'user-1',
+    players: [],
+    lastCard: createMockCard(),
+    hostId: 'user-1',
+    ...overrides,
+  } as GameRoom);
+
+  describe('validate', () => {
+    it('모든 검증이 통과하면 패스해야 한다', () => {
+      const player = createMockPlayer();
+
+      const room = createMockRoom({
+        players: [player],
+        turnOwner: player.userId,
+      });
+
+      expect(() =>
+        validator.validateBase({
+          room,
+          player,
+        }),
+      ).not.toThrow();
+    });
+
+    it('게임이 시작되지 않았을 경우 예외를 던져야 한다', () => {
+      const player = createMockPlayer();
+
+      const room = createMockRoom({
+        status: 'WAITING',
+      });
+
+      expect(() =>
+        validator.validateBase({
+          room,
+          player,
+        }),
+      ).toThrow(WsException);
+    });
+
+    it('플레이어 턴이 아닐 경우 예외를 던져야 한다', () => {
+      const player = createMockPlayer();
+
+      const room = createMockRoom({
+        turnOwner: 'another-user',
+      });
+
+      expect(() =>
+        validator.validateBase({
+          room,
+          player,
+        }),
+      ).toThrow(WsException);
+    });
+
+    it('플레이어가 아웃 상태일 경우 예외를 던져야 한다', () => {
+      const player = createMockPlayer({
+        isOut: true,
+      });
+
+      const room = createMockRoom();
+
+      expect(() =>
+        validator.validateBase({
+          room,
+          player,
+        }),
+      ).toThrow(WsException);
+    });
+
+    it('관전자일 경우 예외를 던져야 한다', () => {
+      const player = createMockPlayer({
+        role: 'SPECTATOR',
+      });
+
+      const room = createMockRoom();
+
+      expect(() =>
+        validator.validateBase({
+          room,
+          player,
+        }),
+      ).toThrow(WsException);
+    });
+  });
+});

--- a/src/modules/game/validators/base-action.validator.ts
+++ b/src/modules/game/validators/base-action.validator.ts
@@ -1,0 +1,77 @@
+import { WsException } from '@nestjs/websockets';
+
+import { Card, GameRoom, Player } from 'src/shared/interfaces/game.interface';
+
+export interface ValidateActionParams {
+  room: GameRoom;
+  player: Player;
+}
+
+/**
+ * 모든 게임 액션의 공통 검증 베이스
+ */
+export abstract class BaseActionValidator {
+  /**
+   * validator 식별용
+   */
+  abstract supports(card: Card): boolean;
+
+  /**
+   * 공통 액션 검증
+   */
+  validateBase(
+    params: ValidateActionParams,
+  ): void {
+    const { room, player } = params;
+
+    this.validateGameStarted(room);
+    this.validatePlayerTurn(room, player);
+    this.validatePlayerState(player);
+  }
+
+  /**
+   * 게임 시작 여부 검증
+   */
+  protected validateGameStarted(
+    room: GameRoom,
+  ): void {
+    if (room.status !== 'PLAYING') {
+      throw new WsException(
+        'Game has not started',
+      );
+    }
+  }
+
+  /**
+   * 현재 턴 플레이어인지 검증
+   */
+  protected validatePlayerTurn(
+    room: GameRoom,
+    player: Player,
+  ): void {
+    if (room.turnOwner !== player.userId) {
+      throw new WsException(
+        'Not player turn',
+      );
+    }
+  }
+
+  /**
+   * 플레이 가능한 상태인지 검증
+   */
+  protected validatePlayerState(
+    player: Player,
+  ): void {
+    if (player.isOut) {
+      throw new WsException(
+        'Player is already out',
+      );
+    }
+
+    if (player.role === 'SPECTATOR') {
+      throw new WsException(
+        'Spectator cannot play',
+      );
+    }
+  }
+}

--- a/src/modules/game/validators/bonus-card-action.validator.spec.ts
+++ b/src/modules/game/validators/bonus-card-action.validator.spec.ts
@@ -1,0 +1,218 @@
+import { WsException } from '@nestjs/websockets';
+
+import {
+  CardSuit,
+  CardType,
+} from 'src/shared/enums/game.enum';
+
+import {
+  GameRoom,
+} from 'src/shared/interfaces/game.interface';
+
+import { BonusCardValidator } from './bonus-card-action.validator';
+import { createSpecialValidatorFixtures } from './special-card-validator.spec.fixture';
+
+describe('BonusCardValidator', () => {
+  let validator: BonusCardValidator;
+
+  beforeEach(() => {
+    validator = new BonusCardValidator();
+  });
+
+  const {
+    createMockCard,
+    createMockPlayer,
+    createMockRoom,
+  } = createSpecialValidatorFixtures(
+    'BONUS',
+    'rabbit_bonus',
+  );
+
+  describe('validate', () => {
+    it('같은 문양이면 성공해야 한다', () => {
+      const card = createMockCard({
+        id: 'card-2',
+        suit: CardSuit.RABBIT,
+      });
+
+      const player = createMockPlayer({
+        hand: [card],
+      });
+
+      const room = createMockRoom({
+        attackStack: 0,
+        lastCard: createMockCard({
+          id: 'last-card',
+          suit: CardSuit.RABBIT,
+          value: '4',
+          type: CardType.NUMBER,
+        }),
+      });
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card,
+        }),
+      ).not.toThrow();
+    });
+
+    it('바닥 카드가 BONUS여도 성공하면 안 된다', () => {
+      const card = createMockCard({
+        id: 'card-2',
+        suit: CardSuit.BEAR,
+      });
+
+      const player = createMockPlayer({
+        hand: [card],
+      });
+
+      const room = createMockRoom({
+        attackStack: 0,
+        lastCard: createMockCard({
+          id: 'last-card',
+          suit: CardSuit.RABBIT,
+          value: 'BONUS',
+          type: CardType.SPECIAL,
+        }),
+      });
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card,
+        }),
+      ).toThrow(WsException);
+    });
+
+    it('문양이 다르면 실패해야 한다', () => {
+      const card = createMockCard({
+        id: 'card-2',
+        suit: CardSuit.BEAR,
+      });
+
+      const player = createMockPlayer({
+        hand: [card],
+      });
+
+      const room = createMockRoom({
+        attackStack: 0,
+        lastCard: createMockCard({
+          id: 'last-card',
+          suit: CardSuit.RABBIT,
+          value: '7',
+          type: CardType.NUMBER,
+        }),
+      });
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card,
+        }),
+      ).toThrow(WsException);
+    });
+
+    it('공격 스택이 존재하면 실패해야 한다', () => {
+      const card = createMockCard({
+        id: 'card-2',
+      });
+
+      const player = createMockPlayer({
+        hand: [card],
+      });
+
+      const room = createMockRoom({
+        attackStack: 2,
+        lastCard: createMockCard({
+          id: 'last-card',
+          suit: CardSuit.RABBIT,
+          value: 'SWORD_2',
+          type: CardType.ATTACK,
+          power: 2,
+        }),
+      });
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card,
+        }),
+      ).toThrow(WsException);
+    });
+
+    it('BONUS 값이 아닌 SPECIAL 카드는 실패해야 한다', () => {
+      const card = createMockCard({
+        id: 'card-2',
+        value: 'REVERSE',
+      });
+
+      const player = createMockPlayer({
+        hand: [card],
+      });
+
+      const room = createMockRoom({
+        attackStack: 0,
+      });
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card,
+        }),
+      ).toThrow(WsException);
+    });
+
+    it('마지막 카드가 없으면 실패해야 한다', () => {
+      const card = createMockCard({
+        id: 'card-2',
+      });
+
+      const player = createMockPlayer({
+        hand: [card],
+      });
+
+      const room = createMockRoom({
+        lastCard: null,
+      });
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card,
+        }),
+      ).toThrow(WsException);
+    });
+  });
+
+  describe('supports', () => {
+    it('BONUS SPECIAL 카드만 지원해야 한다', () => {
+      expect(
+        validator.supports(createMockCard({
+          type: CardType.SPECIAL,
+          value: 'BONUS',
+        })),
+      ).toBe(true);
+
+      expect(
+        validator.supports(createMockCard({
+          type: CardType.SPECIAL,
+          value: 'SHIELD',
+        })),
+      ).toBe(false);
+
+      expect(
+        validator.supports(createMockCard({
+          type: CardType.NUMBER,
+          value: '7',
+        })),
+      ).toBe(false);
+    });
+  });
+});

--- a/src/modules/game/validators/bonus-card-action.validator.ts
+++ b/src/modules/game/validators/bonus-card-action.validator.ts
@@ -1,0 +1,22 @@
+import {
+  AbstractSpecialCardValidator,
+  SpecialCardRuleContext,
+} from './abstract-special-card.validator';
+
+export class BonusCardValidator extends AbstractSpecialCardValidator {
+  protected readonly specialValue = 'BONUS';
+
+  protected canPlayWhenAttackStack(): boolean {
+    return false;
+  }
+
+  protected canPlayWhenNoAttackStack(
+    ctx: SpecialCardRuleContext,
+  ): boolean {
+    return this.isSameSuit(ctx);
+  }
+
+  protected getInvalidPlayMessage(): string {
+    return 'Cannot play bonus card in current state';
+  }
+}

--- a/src/modules/game/validators/card-action.validator.spec.ts
+++ b/src/modules/game/validators/card-action.validator.spec.ts
@@ -1,0 +1,109 @@
+import { WsException } from '@nestjs/websockets';
+
+import {
+  CardSuit,
+  CardType,
+  GameDirection,
+} from 'src/shared/enums/game.enum';
+
+import {
+  Card,
+  GameRoom,
+  Player,
+} from 'src/shared/interfaces/game.interface';
+
+import {
+  CardActionValidator,
+  ValidateCardActionParams,
+} from './card-action.validator';
+
+describe('CardActionValidator', () => {
+  class TestCardValidator extends CardActionValidator {
+    supports(_card: Card): boolean {
+      return true;
+    }
+
+    protected validateRule(): void {
+      // no-op
+    }
+  }
+
+  let validator: TestCardValidator;
+
+  beforeEach(() => {
+    validator = new TestCardValidator();
+  });
+
+  const createMockCard = (overrides: Partial<Card> = {}): Card => ({
+    id: 'card-1',
+    suit: CardSuit.RABBIT,
+    value: '1',
+    type: CardType.NUMBER,
+    power: 0,
+    assetKey: 'rabbit_1',
+    ...overrides,
+  });
+
+  const createMockPlayer = (overrides: Partial<Player> = {}): Player => ({
+    userId: 'user-1',
+    nickname: 'tester',
+    role: 'PLAYER',
+    isGuest: false,
+    isOut: false,
+    isReady: true,
+    cardCount: 1,
+    hand: [createMockCard()],
+    ...overrides,
+  });
+
+  const createMockRoom = (overrides: Partial<GameRoom> = {}): GameRoom => ({
+    roomId: 'room-1',
+    hostId: 'user-1',
+    status: 'PLAYING',
+    turnOwner: 'user-1',
+    players: [],
+    lastCard: createMockCard({id: 'card-2'}),
+    ...overrides,
+  }) as GameRoom;
+
+  describe('validate', () => {
+    it('모든 검증이 통과하면 성공해야 한다', () => {
+      const player = createMockPlayer();
+
+      const room = createMockRoom({
+        players: [player],
+        turnOwner: player.userId,
+      });
+
+      const card = player.hand[0];
+
+      expect(() =>
+        validator.validate({
+          room,
+          player,
+          card,
+        }),
+      ).not.toThrow();
+    });
+
+    it('플레이어가 소유하지 않은 카드면 예외를 던져야 한다', () => {
+      const player = createMockPlayer();
+
+      const room = createMockRoom({
+        players: [player],
+      });
+
+      const card = createMockCard({
+        id: 'card-3',
+      });
+
+      expect(() =>
+        validator.validate({
+          room,
+          player,
+          card,
+        }),
+      ).toThrow(WsException);
+    });
+  });
+});

--- a/src/modules/game/validators/card-action.validator.ts
+++ b/src/modules/game/validators/card-action.validator.ts
@@ -1,0 +1,64 @@
+import { WsException } from '@nestjs/websockets';
+
+import {
+  Card,
+  GameRoom,
+  Player,
+} from 'src/shared/interfaces/game.interface';
+import { BaseActionValidator, ValidateActionParams } from './base-action.validator';
+
+export interface ValidateCardActionParams extends ValidateActionParams {
+  card: Card;
+}
+
+/**
+ * 카드 액션 전용 validator
+ */
+export abstract class CardActionValidator extends BaseActionValidator {
+
+  /**
+   * 카드 액션 검증 진입점
+   */
+  validate(
+    params: ValidateCardActionParams,
+  ): void {
+    const { player, room, card } = params;
+
+    // 공통 액션 검증
+    this.validateBase({player, room});
+
+    // 카드 ownership 검증
+    this.validateCardOwnership(
+      player,
+      card.id,
+    );
+
+    // 카드별 세부 규칙 검증
+    this.validateRule(params);
+  }
+
+  /**
+   * 카드별 세부 규칙 구현
+   */
+  protected abstract validateRule(
+    params: ValidateCardActionParams,
+  ): void;
+
+  /**
+   * 실제 플레이어 소유 카드인지 검증
+   */
+  protected validateCardOwnership(
+    player: Player,
+    cardId: string,
+  ): void {
+    const hasCard = player.hand.some(
+      (card) => card.id === cardId,
+    );
+
+    if (!hasCard) {
+      throw new WsException(
+        'Player does not own this card',
+      );
+    }
+  }
+}

--- a/src/modules/game/validators/evade-card-action.validator.spec.ts
+++ b/src/modules/game/validators/evade-card-action.validator.spec.ts
@@ -1,0 +1,241 @@
+import { WsException } from '@nestjs/websockets';
+
+import {
+  CardSuit,
+  CardType,
+} from 'src/shared/enums/game.enum';
+
+import {
+  GameRoom,
+} from 'src/shared/interfaces/game.interface';
+
+import { EvadeCardValidator } from './evade-card-action.validator';
+import { createSpecialValidatorFixtures } from './special-card-validator.spec.fixture';
+
+describe('EvadeCardValidator', () => {
+  let validator: EvadeCardValidator;
+
+  beforeEach(() => {
+    validator = new EvadeCardValidator();
+  });
+
+  const {
+    createMockCard,
+    createMockPlayer,
+    createMockRoom,
+  } = createSpecialValidatorFixtures(
+    'EVADE',
+    'rabbit_evade',
+  );
+
+  describe('validate', () => {
+    it('공격 스택이 존재하면 성공해야 한다', () => {
+      const card = createMockCard({
+        id: 'card-2',
+      });
+
+      const player = createMockPlayer({
+        hand: [card],
+      });
+
+      const room = createMockRoom({
+        attackStack: 2,
+      });
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card,
+        }),
+      ).not.toThrow();
+    });
+
+    it('공격 수치와 관계없이 EVADE는 공격을 회피할 수 있어야 한다', () => {
+      const card = createMockCard({
+        id: 'card-2',
+      });
+
+      const player = createMockPlayer({
+        hand: [card],
+      });
+
+      const room = createMockRoom({
+        attackStack: 7,
+        lastCard: createMockCard({
+          id: 'last-card',
+          suit: CardSuit.BEAR,
+          value: 'SWORD_3',
+          type: CardType.ATTACK,
+          power: 3,
+        }),
+      });
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card,
+        }),
+      ).not.toThrow();
+    });
+
+    it('공격 스택이 없어도 바닥 카드가 EVADE면 성공해야 한다', () => {
+      const card = createMockCard({
+        id: 'card-2',
+      });
+
+      const player = createMockPlayer({
+        hand: [card],
+      });
+
+      const room = createMockRoom({
+        attackStack: 0,
+        lastCard: createMockCard({
+          id: 'last-card',
+          suit: CardSuit.BEAR,
+          value: 'EVADE',
+          type: CardType.SPECIAL,
+        }),
+      });
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card,
+        }),
+      ).not.toThrow();
+    });
+
+    it('공격 스택이 없어도 같은 문양이면 성공해야 한다', () => {
+      const card = createMockCard({
+        id: 'card-2',
+        suit: CardSuit.BEAR,
+      });
+
+      const player = createMockPlayer({
+        hand: [card],
+      });
+
+      const room = createMockRoom({
+        attackStack: 0,
+        lastCard: createMockCard({
+          id: 'last-card',
+          suit: CardSuit.BEAR,
+          value: '7',
+          type: CardType.NUMBER,
+        }),
+      });
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card,
+        }),
+      ).not.toThrow();
+    });
+
+    it('공격 스택이 없고 바닥 카드가 EVADE도 아니며 문양도 다르면 실패해야 한다', () => {
+      const card = createMockCard({
+        id: 'card-2',
+        suit: CardSuit.CAT,
+      });
+
+      const player = createMockPlayer({
+        hand: [card],
+      });
+
+      const room = createMockRoom({
+        attackStack: 0,
+        lastCard: createMockCard({
+          id: 'last-card',
+          suit: CardSuit.BEAR,
+          value: '7',
+          type: CardType.NUMBER,
+        }),
+      });
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card,
+        }),
+      ).toThrow(WsException);
+    });
+
+    it('EVADE 값이 아닌 SPECIAL 카드는 실패해야 한다', () => {
+      const card = createMockCard({
+        id: 'card-2',
+        value: 'SHIELD',
+      });
+
+      const player = createMockPlayer({
+        hand: [card],
+      });
+
+      const room = createMockRoom({
+        attackStack: 2,
+      });
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card,
+        }),
+      ).toThrow(WsException);
+    });
+
+    it('마지막 카드가 없으면 실패해야 한다', () => {
+      const card = createMockCard({
+        id: 'card-2',
+      });
+
+      const player = createMockPlayer({
+        hand: [card],
+      });
+
+      const room = createMockRoom({
+        attackStack: 2,
+        lastCard: null,
+      });
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card,
+        }),
+      ).toThrow(WsException);
+    });
+  });
+
+  describe('supports', () => {
+    it('EVADE SPECIAL 카드만 지원해야 한다', () => {
+      expect(
+        validator.supports(createMockCard({
+          type: CardType.SPECIAL,
+          value: 'EVADE',
+        })),
+      ).toBe(true);
+
+      expect(
+        validator.supports(createMockCard({
+          type: CardType.SPECIAL,
+          value: 'SHIELD',
+        })),
+      ).toBe(false);
+
+      expect(
+        validator.supports(createMockCard({
+          type: CardType.ATTACK,
+          value: 'SWORD_3',
+          power: 3,
+        })),
+      ).toBe(false);
+    });
+  });
+});

--- a/src/modules/game/validators/evade-card-action.validator.ts
+++ b/src/modules/game/validators/evade-card-action.validator.ts
@@ -1,0 +1,22 @@
+import {
+  AbstractSpecialCardValidator,
+  SpecialCardRuleContext,
+} from './abstract-special-card.validator';
+
+export class EvadeCardValidator extends AbstractSpecialCardValidator {
+  protected readonly specialValue = 'EVADE';
+
+  protected canPlayWhenAttackStack(): boolean {
+    return true;
+  }
+
+  protected canPlayWhenNoAttackStack(
+    ctx: SpecialCardRuleContext,
+  ): boolean {
+    return this.isSameSuit(ctx) || this.isSameValue(ctx);
+  }
+
+  protected getInvalidPlayMessage(): string {
+    return 'Cannot play evade card in current state';
+  }
+}

--- a/src/modules/game/validators/normal-card-action.validator.spec.ts
+++ b/src/modules/game/validators/normal-card-action.validator.spec.ts
@@ -1,0 +1,205 @@
+import { WsException } from '@nestjs/websockets';
+
+import {
+  CardSuit,
+  CardType,
+} from 'src/shared/enums/game.enum';
+
+import {
+  Card,
+  GameRoom,
+  Player,
+} from 'src/shared/interfaces/game.interface';
+
+import { NormalCardValidator } from './normal-card-action.validator';
+
+describe('NormalCardValidator', () => {
+  let validator: NormalCardValidator;
+
+  beforeEach(() => {
+    validator = new NormalCardValidator();
+  });
+
+  const createMockCard = (
+    overrides: Partial<Card> = {},
+  ): Card => ({
+    id: 'card-1',
+    suit: CardSuit.RABBIT,
+    value: '1',
+    type: CardType.NUMBER,
+    power: 0,
+    assetKey: 'rabbit_1',
+    ...overrides,
+  });
+
+  const createMockPlayer = (
+    overrides: Partial<Player> = {},
+  ): Player => ({
+    userId: 'user-1',
+    nickname: 'tester',
+    role: 'PLAYER',
+    isGuest: false,
+    isOut: false,
+    isReady: true,
+    cardCount: 1,
+    hand: [createMockCard()],
+    ...overrides,
+  });
+
+  const createMockRoom = (
+    overrides: Partial<GameRoom> = {},
+  ): Partial<GameRoom> => ({
+    roomId: 'room-1',
+    hostId: 'user-1',
+    status: 'PLAYING',
+    turnOwner: 'user-1',
+    players: [],
+    lastCard: createMockCard({
+      id: 'last-card',
+      suit: CardSuit.RABBIT,
+      value: '3',
+    }),
+    ...overrides,
+  });
+
+  describe('validate', () => {
+    it('같은 문양이면 성공해야 한다', () => {
+      const card = createMockCard({
+        id: 'card-2',
+        suit: CardSuit.RABBIT,
+        value: '7',
+      });
+
+      const player = createMockPlayer({
+        hand: [card],
+      });
+
+      const room = createMockRoom();
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card,
+        }),
+      ).not.toThrow();
+    });
+
+    it('같은 숫자면 성공해야 한다', () => {
+      const card = createMockCard({
+        id: 'card-2',
+        suit: CardSuit.BEAR,
+        value: '3',
+      });
+
+      const player = createMockPlayer({
+        hand: [card],
+      });
+
+      const room = createMockRoom();
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card,
+        }),
+      ).not.toThrow();
+    });
+
+    it('문양과 숫자가 모두 다르면 실패해야 한다', () => {
+      const card = createMockCard({
+        id: 'card-2',
+        suit: CardSuit.BEAR,
+        value: '9',
+      });
+
+      const player = createMockPlayer({
+        hand: [card],
+      });
+
+      const room = createMockRoom({
+        lastCard: createMockCard({
+          id: 'last-card',
+          suit: CardSuit.RABBIT,
+          value: '1',
+        }),
+      });
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card,
+        }),
+      ).toThrow(WsException);
+    });
+
+    it('마지막 카드가 없으면 실패해야 한다', () => {
+      const card = createMockCard({
+        id: 'card-2',
+      });
+
+      const player = createMockPlayer({
+        hand: [card],
+      });
+
+      const room = createMockRoom({
+        lastCard: null,
+      });
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card,
+        }),
+      ).toThrow(WsException);
+    });
+
+    it('NUMBER 타입 카드만 지원해야 한다', () => {
+      expect(
+        validator.supports(createMockCard({
+          type: CardType.NUMBER,
+          value: '7',
+        })),
+      ).toBe(true);
+
+      expect(
+        validator.supports(createMockCard({
+          type: CardType.ATTACK,
+          value: 'SWORD_2',
+          power: 2,
+        })),
+      ).toBe(false);
+    });
+
+    it('공격 스택이 존재할 경우 일반 숫자 카드를 낼 수 없어야 한다', () => {
+      const card = createMockCard({
+        id: 'card-2',
+        type: CardType.NUMBER,
+      });
+
+      const player = createMockPlayer({
+        hand: [card],
+      });
+
+      const room = createMockRoom({
+        attackStack: 2,
+        lastCard: createMockCard({ // 같은 동물 RABBIT이지만 공격 스택이 존재하므로 일반 카드로는 낼 수 없음
+          type: CardType.ATTACK,
+          value: 'SWORD_2',
+          power: 2,
+        }),
+      });
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card,
+        }),
+      ).toThrow(WsException);
+    });
+  });
+});

--- a/src/modules/game/validators/normal-card-action.validator.ts
+++ b/src/modules/game/validators/normal-card-action.validator.ts
@@ -1,0 +1,53 @@
+import { WsException } from '@nestjs/websockets';
+
+import {
+  CardType,
+} from 'src/shared/enums/game.enum';
+import { Card } from 'src/shared/interfaces/game.interface';
+
+import {
+  ValidateCardActionParams,
+  CardActionValidator,
+} from './card-action.validator';
+
+export class NormalCardValidator extends CardActionValidator {
+
+  supports(card: Card): boolean {
+    return card.type === CardType.NUMBER;
+  }
+
+  protected validateRule(
+    params: ValidateCardActionParams,
+  ): void {
+    const { room, card } = params;
+
+    const lastCard = room.lastCard;
+
+    // 마지막 카드가 존재해야 함
+    if (!lastCard) {
+      throw new WsException(
+        'Last card does not exist',
+      );
+    }
+
+    // 공격 스택이 존재하면 일반 숫자 카드 사용 불가
+    if (room.attackStack > 0) {
+      throw new WsException(
+        'Cannot play normal card during attack stack',
+      );
+    }
+
+    const isSameSuit =
+      lastCard.suit === card.suit;
+
+    const isSameValue =
+      lastCard.value === card.value;
+
+    // 문양 또는 숫자가 같아야 함
+    if (!isSameSuit && !isSameValue) {
+      throw new WsException(
+        'Card does not match last card',
+      );
+    }
+  }
+}

--- a/src/modules/game/validators/reverse-card-action.validator.spec.ts
+++ b/src/modules/game/validators/reverse-card-action.validator.spec.ts
@@ -1,0 +1,242 @@
+import { WsException } from '@nestjs/websockets';
+
+import {
+  CardSuit,
+  CardType,
+} from 'src/shared/enums/game.enum';
+
+import {
+  GameRoom,
+} from 'src/shared/interfaces/game.interface';
+
+import { ReverseCardValidator } from './reverse-card-action.validator';
+import { createSpecialValidatorFixtures } from './special-card-validator.spec.fixture';
+
+describe('ReverseCardValidator', () => {
+  let validator: ReverseCardValidator;
+
+  beforeEach(() => {
+    validator = new ReverseCardValidator();
+  });
+
+  const {
+    createMockCard,
+    createMockPlayer,
+    createMockRoom,
+  } = createSpecialValidatorFixtures(
+    'REVERSE',
+    'rabbit_reverse',
+  );
+
+  describe('validate', () => {
+    it('공격 스택이 없고 같은 문양이면 성공해야 한다', () => {
+      const card = createMockCard({
+        id: 'card-2',
+        suit: CardSuit.RABBIT,
+      });
+
+      const player = createMockPlayer({
+        hand: [card],
+      });
+
+      const room = createMockRoom({
+        attackStack: 0,
+      });
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card,
+        }),
+      ).not.toThrow();
+    });
+
+    it('공격 스택이 없고 같은 값(REVERSE)이면 성공해야 한다', () => {
+      const card = createMockCard({
+        id: 'card-2',
+        suit: CardSuit.BEAR,
+      });
+
+      const player = createMockPlayer({
+        hand: [card],
+      });
+
+      const room = createMockRoom({
+        attackStack: 0,
+        lastCard: createMockCard({
+          id: 'last-card',
+          suit: CardSuit.RABBIT,
+          value: 'REVERSE',
+          type: CardType.SPECIAL,
+        }),
+      });
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card,
+        }),
+      ).not.toThrow();
+    });
+
+    it('문양과 값이 모두 다르면 실패해야 한다', () => {
+      const card = createMockCard({
+        id: 'card-2',
+        suit: CardSuit.BEAR,
+      });
+
+      const player = createMockPlayer({
+        hand: [card],
+      });
+
+      const room = createMockRoom({
+        attackStack: 0,
+        lastCard: createMockCard({
+          id: 'last-card',
+          suit: CardSuit.RABBIT,
+          value: '3',
+          type: CardType.NUMBER,
+        }),
+      });
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card,
+        }),
+      ).toThrow(WsException);
+    });
+
+    it('공격 스택이 존재하면 실패해야 한다', () => {
+      const card = createMockCard({
+        id: 'card-2',
+      });
+
+      const player = createMockPlayer({
+        hand: [card],
+      });
+
+      const room = createMockRoom({
+        attackStack: 2,
+        lastCard: createMockCard({
+          id: 'last-card',
+          suit: CardSuit.RABBIT,
+          value: 'SWORD_2',
+          type: CardType.ATTACK,
+          power: 2,
+        }),
+      });
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card,
+        }),
+      ).toThrow(WsException);
+    });
+
+    it('공격 스택 중에는 같은 REVERSE 카드여도 실패해야 한다', () => {
+      const card = createMockCard({
+        id: 'card-2',
+        suit: CardSuit.BEAR,
+      });
+
+      const player = createMockPlayer({
+        hand: [card],
+      });
+
+      const room = createMockRoom({
+        attackStack: 2,
+        lastCard: createMockCard({
+          id: 'last-card',
+          suit: CardSuit.RABBIT,
+          value: 'REVERSE',
+          type: CardType.SPECIAL,
+        }),
+      });
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card,
+        }),
+      ).toThrow(WsException);
+    });
+
+    it('REVERSE 값이 아닌 SPECIAL 카드는 실패해야 한다', () => {
+      const card = createMockCard({
+        id: 'card-2',
+        value: 'JUMP',
+      });
+
+      const player = createMockPlayer({
+        hand: [card],
+      });
+
+      const room = createMockRoom({
+        attackStack: 0,
+      });
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card,
+        }),
+      ).toThrow(WsException);
+    });
+
+    it('마지막 카드가 없으면 실패해야 한다', () => {
+      const card = createMockCard({
+        id: 'card-2',
+      });
+
+      const player = createMockPlayer({
+        hand: [card],
+      });
+
+      const room = createMockRoom({
+        lastCard: null,
+      });
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card,
+        }),
+      ).toThrow(WsException);
+    });
+  });
+
+  describe('supports', () => {
+    it('REVERSE SPECIAL 카드만 지원해야 한다', () => {
+      expect(
+        validator.supports(createMockCard({
+          type: CardType.SPECIAL,
+          value: 'REVERSE',
+        })),
+      ).toBe(true);
+
+      expect(
+        validator.supports(createMockCard({
+          type: CardType.SPECIAL,
+          value: 'JUMP',
+        })),
+      ).toBe(false);
+
+      expect(
+        validator.supports(createMockCard({
+          type: CardType.ATTACK,
+          value: 'SWORD_2',
+          power: 2,
+        })),
+      ).toBe(false);
+    });
+  });
+});

--- a/src/modules/game/validators/reverse-card-action.validator.ts
+++ b/src/modules/game/validators/reverse-card-action.validator.ts
@@ -1,0 +1,22 @@
+import {
+  AbstractSpecialCardValidator,
+  SpecialCardRuleContext,
+} from './abstract-special-card.validator';
+
+export class ReverseCardValidator extends AbstractSpecialCardValidator {
+  protected readonly specialValue = 'REVERSE';
+
+  protected canPlayWhenAttackStack(): boolean {
+    return false;
+  }
+
+  protected canPlayWhenNoAttackStack(
+    ctx: SpecialCardRuleContext,
+  ): boolean {
+    return this.isSameSuit(ctx) || this.isSameValue(ctx);
+  }
+
+  protected getInvalidPlayMessage(): string {
+    return 'Cannot play reverse card in current state';
+  }
+}

--- a/src/modules/game/validators/shield-card-action.validator.spec.ts
+++ b/src/modules/game/validators/shield-card-action.validator.spec.ts
@@ -1,0 +1,211 @@
+import { WsException } from '@nestjs/websockets';
+
+import {
+  CardSuit,
+  CardType,
+} from 'src/shared/enums/game.enum';
+
+import {
+  GameRoom,
+} from 'src/shared/interfaces/game.interface';
+
+import { ShieldCardValidator } from './shield-card-action.validator';
+import { createSpecialValidatorFixtures } from './special-card-validator.spec.fixture';
+
+describe('ShieldCardValidator', () => {
+  let validator: ShieldCardValidator;
+
+  beforeEach(() => {
+    validator = new ShieldCardValidator();
+  });
+
+  const {
+    createMockCard,
+    createMockPlayer,
+    createMockRoom,
+  } = createSpecialValidatorFixtures(
+    'SHIELD',
+    'rabbit_shield',
+  );
+
+  describe('validate', () => {
+    it('공격 스택이 존재하면 성공해야 한다', () => {
+      const card = createMockCard({
+        id: 'card-2',
+      });
+
+      const player = createMockPlayer({
+        hand: [card],
+      });
+
+      const room = createMockRoom({
+        attackStack: 2,
+      });
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card,
+        }),
+      ).not.toThrow();
+    });
+
+    it('공격 스택이 없어도 바닥 카드가 SHIELD면 성공해야 한다', () => {
+      const card = createMockCard({
+        id: 'card-2',
+      });
+
+      const player = createMockPlayer({
+        hand: [card],
+      });
+
+      const room = createMockRoom({
+        attackStack: 0,
+        lastCard: createMockCard({
+          id: 'last-card',
+          suit: CardSuit.BEAR,
+          value: 'SHIELD',
+          type: CardType.SPECIAL,
+        }),
+      });
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card,
+        }),
+      ).not.toThrow();
+    });
+
+    it('공격 스택이 없고 바닥 카드가 SHIELD가 아니며 모양도 다르면 실패해야 한다', () => {
+      const card = createMockCard({
+        id: 'card-2',
+      });
+
+      const player = createMockPlayer({
+        hand: [card],
+      });
+
+      const room = createMockRoom({
+        attackStack: 0,
+        lastCard: createMockCard({
+          id: 'last-card',
+          suit: CardSuit.BEAR,
+          value: '7',
+          type: CardType.NUMBER,
+        }),
+      });
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card,
+        }),
+      ).toThrow(WsException);
+    });
+
+    it('공격 스택이 없어도 같은 문양이면 성공해야 한다', () => {
+      const card = createMockCard({
+        id: 'card-2',
+        suit: CardSuit.BEAR,
+      });
+
+      const player = createMockPlayer({
+        hand: [card],
+      });
+
+      const room = createMockRoom({
+        attackStack: 0,
+        lastCard: createMockCard({
+          id: 'last-card',
+          suit: CardSuit.BEAR,
+          value: '7',
+          type: CardType.NUMBER,
+        }),
+      });
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card,
+        }),
+      ).not.toThrow();
+    });
+
+    it('SHIELD 값이 아닌 SPECIAL 카드는 실패해야 한다', () => {
+      const card = createMockCard({
+        id: 'card-2',
+        value: 'EVADE',
+      });
+
+      const player = createMockPlayer({
+        hand: [card],
+      });
+
+      const room = createMockRoom({
+        attackStack: 2,
+      });
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card,
+        }),
+      ).toThrow(WsException);
+    });
+
+    it('마지막 카드가 없으면 실패해야 한다', () => {
+      const card = createMockCard({
+        id: 'card-2',
+      });
+
+      const player = createMockPlayer({
+        hand: [card],
+      });
+
+      const room = createMockRoom({
+        attackStack: 2,
+        lastCard: null,
+      });
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card,
+        }),
+      ).toThrow(WsException);
+    });
+  });
+
+  describe('supports', () => {
+    it('SHIELD SPECIAL 카드만 지원해야 한다', () => {
+      expect(
+        validator.supports(createMockCard({
+          type: CardType.SPECIAL,
+          value: 'SHIELD',
+        })),
+      ).toBe(true);
+
+      expect(
+        validator.supports(createMockCard({
+          type: CardType.SPECIAL,
+          value: 'EVADE',
+        })),
+      ).toBe(false);
+
+      expect(
+        validator.supports(createMockCard({
+          type: CardType.ATTACK,
+          value: 'SWORD_1',
+          power: 1,
+        })),
+      ).toBe(false);
+    });
+  });
+});

--- a/src/modules/game/validators/shield-card-action.validator.ts
+++ b/src/modules/game/validators/shield-card-action.validator.ts
@@ -1,0 +1,22 @@
+import {
+  AbstractSpecialCardValidator,
+  SpecialCardRuleContext,
+} from './abstract-special-card.validator';
+
+export class ShieldCardValidator extends AbstractSpecialCardValidator {
+  protected readonly specialValue = 'SHIELD';
+
+  protected canPlayWhenAttackStack(): boolean {
+    return true;
+  }
+
+  protected canPlayWhenNoAttackStack(
+    ctx: SpecialCardRuleContext,
+  ): boolean {
+    return this.isSameSuit(ctx) || this.isSameValue(ctx);
+  }
+
+  protected getInvalidPlayMessage(): string {
+    return 'Cannot play shield card in current state';
+  }
+}

--- a/src/modules/game/validators/skip-card-action.validator.spec.ts
+++ b/src/modules/game/validators/skip-card-action.validator.spec.ts
@@ -1,0 +1,256 @@
+import { WsException } from '@nestjs/websockets';
+
+import {
+  CardSuit,
+  CardType,
+} from 'src/shared/enums/game.enum';
+
+import {
+  GameRoom,
+} from 'src/shared/interfaces/game.interface';
+
+import { SkipCardValidator } from './skip-card-action.validator';
+import { createSpecialValidatorFixtures } from './special-card-validator.spec.fixture';
+
+describe('SkipCardValidator', () => {
+  let validator: SkipCardValidator;
+
+  beforeEach(() => {
+    validator = new SkipCardValidator();
+  });
+
+  const {
+    createMockCard,
+    createMockPlayer,
+    createMockRoom,
+  } = createSpecialValidatorFixtures(
+    'JUMP',
+    'rabbit_jump',
+  );
+
+  describe('validate', () => {
+    it('공격 스택이 없고 같은 문양이면 성공해야 한다', () => {
+      const card = createMockCard({
+        id: 'card-2',
+        suit: CardSuit.RABBIT,
+      });
+
+      const player = createMockPlayer({
+        hand: [card],
+      });
+
+      const room = createMockRoom({
+        attackStack: 0,
+        lastCard: createMockCard({
+          id: 'last-card',
+          suit: CardSuit.RABBIT,
+          value: '3',
+          type: CardType.NUMBER,
+        }),
+      });
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card,
+        }),
+      ).not.toThrow();
+    });
+
+    it('공격 스택이 없고 같은 값(JUMP)이면 성공해야 한다', () => {
+      const card = createMockCard({
+        id: 'card-2',
+        suit: CardSuit.BEAR,
+        value: 'JUMP',
+      });
+
+      const player = createMockPlayer({
+        hand: [card],
+      });
+
+      const room = createMockRoom({
+        attackStack: 0,
+        lastCard: createMockCard({
+          id: 'last-card',
+          suit: CardSuit.RABBIT,
+          value: 'JUMP',
+          type: CardType.SPECIAL,
+        }),
+      });
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card,
+        }),
+      ).not.toThrow();
+    });
+
+    it('문양과 값이 모두 다르면 실패해야 한다', () => {
+      const card = createMockCard({
+        id: 'card-2',
+        suit: CardSuit.BEAR,
+        value: 'JUMP',
+      });
+
+      const player = createMockPlayer({
+        hand: [card],
+      });
+
+      const room = createMockRoom({
+        attackStack: 0,
+        lastCard: createMockCard({
+          id: 'last-card',
+          suit: CardSuit.RABBIT,
+          value: '3',
+          type: CardType.NUMBER,
+        }),
+      });
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card,
+        }),
+      ).toThrow(WsException);
+    });
+
+    it('공격 스택이 존재하면 실패해야 한다', () => {
+      const card = createMockCard({
+        id: 'card-2',
+      });
+
+      const player = createMockPlayer({
+        hand: [card],
+      });
+
+      const room = createMockRoom({
+        attackStack: 2,
+        lastCard: createMockCard({
+          id: 'last-card',
+          suit: CardSuit.RABBIT,
+          value: 'SWORD_2',
+          type: CardType.ATTACK,
+          power: 2,
+        }),
+      });
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card,
+        }),
+      ).toThrow(WsException);
+    });
+
+    it('공격 스택 중에는 같은 JUMP 카드여도 실패해야 한다', () => {
+      const card = createMockCard({
+        id: 'card-2',
+        suit: CardSuit.BEAR,
+        value: 'JUMP',
+      });
+
+      const player = createMockPlayer({
+        hand: [card],
+      });
+
+      const room = createMockRoom({
+        attackStack: 2,
+        lastCard: createMockCard({
+          id: 'last-card',
+          suit: CardSuit.RABBIT,
+          value: 'JUMP',
+          type: CardType.SPECIAL,
+        }),
+      });
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card,
+        }),
+      ).toThrow(WsException);
+    });
+
+    it('JUMP 값이 아닌 SPECIAL 카드는 실패해야 한다', () => {
+      const card = createMockCard({
+        id: 'card-2',
+        value: 'REVERSE',
+      });
+
+      const player = createMockPlayer({
+        hand: [card],
+      });
+
+      const room = createMockRoom({
+        attackStack: 0,
+        lastCard: createMockCard({
+          id: 'last-card',
+          suit: CardSuit.RABBIT,
+          value: 'JUMP',
+          type: CardType.SPECIAL,
+        }),
+      });
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card,
+        }),
+      ).toThrow(WsException);
+    });
+
+    it('마지막 카드가 없으면 실패해야 한다', () => {
+      const card = createMockCard({
+        id: 'card-2',
+      });
+
+      const player = createMockPlayer({
+        hand: [card],
+      });
+
+      const room = createMockRoom({
+        lastCard: null,
+      });
+
+      expect(() =>
+        validator.validate({
+          room: room as GameRoom,
+          player,
+          card,
+        }),
+      ).toThrow(WsException);
+    });
+  });
+
+  describe('supports', () => {
+    it('JUMP SPECIAL 카드만 지원해야 한다', () => {
+      expect(
+        validator.supports(createMockCard({
+          type: CardType.SPECIAL,
+          value: 'JUMP',
+        })),
+      ).toBe(true);
+
+      expect(
+        validator.supports(createMockCard({
+          type: CardType.SPECIAL,
+          value: 'REVERSE',
+        })),
+      ).toBe(false);
+
+      expect(
+        validator.supports(createMockCard({
+          type: CardType.NUMBER,
+          value: '7',
+        })),
+      ).toBe(false);
+    });
+  });
+});

--- a/src/modules/game/validators/skip-card-action.validator.ts
+++ b/src/modules/game/validators/skip-card-action.validator.ts
@@ -1,0 +1,22 @@
+import {
+  AbstractSpecialCardValidator,
+  SpecialCardRuleContext,
+} from './abstract-special-card.validator';
+
+export class SkipCardValidator extends AbstractSpecialCardValidator {
+  protected readonly specialValue = 'JUMP';
+
+  protected canPlayWhenAttackStack(): boolean {
+    return false;
+  }
+
+  protected canPlayWhenNoAttackStack(
+    ctx: SpecialCardRuleContext,
+  ): boolean {
+    return this.isSameSuit(ctx) || this.isSameValue(ctx);
+  }
+
+  protected getInvalidPlayMessage(): string {
+    return 'Cannot play skip card in current state';
+  }
+}

--- a/src/modules/game/validators/special-card-validator.spec.fixture.ts
+++ b/src/modules/game/validators/special-card-validator.spec.fixture.ts
@@ -1,0 +1,67 @@
+import {
+  CardSuit,
+  CardType,
+  GameDirection,
+} from 'src/shared/enums/game.enum';
+import {
+  Card,
+  GameRoom,
+  Player,
+} from 'src/shared/interfaces/game.interface';
+
+export function createSpecialValidatorFixtures(
+  specialValue: string,
+  assetKey: string,
+) {
+  const createMockCard = (
+    overrides: Partial<Card> = {},
+  ): Card => ({
+    id: 'card-1',
+    suit: CardSuit.RABBIT,
+    value: specialValue,
+    type: CardType.SPECIAL,
+    power: 0,
+    assetKey,
+    ...overrides,
+  });
+
+  const createMockPlayer = (
+    overrides: Partial<Player> = {},
+  ): Player => ({
+    userId: 'user-1',
+    nickname: 'tester',
+    role: 'PLAYER',
+    isGuest: false,
+    isOut: false,
+    isReady: true,
+    cardCount: 1,
+    hand: [createMockCard()],
+    ...overrides,
+  });
+
+  const createMockRoom = (
+    overrides: Partial<GameRoom> = {},
+  ): Partial<GameRoom> => ({
+    roomId: 'room-1',
+    hostId: 'user-1',
+    status: 'PLAYING',
+    turnOwner: 'user-1',
+    direction: GameDirection.CLOCKWISE,
+    attackStack: 0,
+    isBonusTurn: false,
+    players: [],
+    lastCard: createMockCard({
+      id: 'last-card',
+      suit: CardSuit.RABBIT,
+      value: '7',
+      type: CardType.NUMBER,
+    }),
+    ...overrides,
+  });
+
+  return {
+    createMockCard,
+    createMockPlayer,
+    createMockRoom,
+  };
+}

--- a/src/modules/socket/game.module.ts
+++ b/src/modules/socket/game.module.ts
@@ -6,6 +6,15 @@ import { GameSetupService } from "../game/game-setup.service";
 import { GameService } from "../game/game.service";
 import { MaskingService } from "./masking.service";
 import { GameResponseInterceptor } from "./interceptors/game-response.interceptor";
+import { ActionValidatorRegistry } from "../game/validators/action-validator.registry";
+import { ACTION_VALIDATORS } from "../game/validators/action-validator.token";
+import { AttackCardValidator } from "../game/validators/attack-card-action.validator";
+import { NormalCardValidator } from "../game/validators/normal-card-action.validator";
+import { SkipCardValidator } from "../game/validators/skip-card-action.validator";
+import { ReverseCardValidator } from "../game/validators/reverse-card-action.validator";
+import { ShieldCardValidator } from "../game/validators/shield-card-action.validator";
+import { EvadeCardValidator } from "../game/validators/evade-card-action.validator";
+import { BonusCardValidator } from "../game/validators/bonus-card-action.validator";
 
 @Module({
   imports: [AuthModule],
@@ -15,7 +24,44 @@ import { GameResponseInterceptor } from "./interceptors/game-response.intercepto
     GameService,
     GameSetupService,
     MaskingService,
-    GameResponseInterceptor
+    GameResponseInterceptor,
+    ActionValidatorRegistry,
+    AttackCardValidator,
+    NormalCardValidator,
+    SkipCardValidator,
+    ReverseCardValidator,
+    ShieldCardValidator,
+    EvadeCardValidator,
+    BonusCardValidator,
+    {
+      provide: ACTION_VALIDATORS,
+      useFactory: (
+        attack: AttackCardValidator,
+        normal: NormalCardValidator,
+        skip: SkipCardValidator,
+        reverse: ReverseCardValidator,
+        shield: ShieldCardValidator,
+        evade: EvadeCardValidator,
+        bonus: BonusCardValidator,
+      ) => [
+        attack,
+        normal,
+        skip,
+        reverse,
+        shield,
+        evade,
+        bonus,
+      ],
+      inject: [
+        AttackCardValidator,
+        NormalCardValidator,
+        SkipCardValidator,
+        ReverseCardValidator,
+        ShieldCardValidator,
+        EvadeCardValidator,
+        BonusCardValidator,
+      ],
+    },
   ],
   exports: [MaskingService],
 })


### PR DESCRIPTION
### 🚀 주요 작업 내용
- 게임 액션 검증 계층 신설
- `BaseActionValidator` / `CardActionValidator` 도입
  - 공통 검증 분리: 게임 시작 여부, 턴 소유자, 플레이어 상태, 카드 소유권
- 카드 타입별 validator 추가
  - `AttackCardValidator`
  - `NormalCardValidator`
  - `SkipCardValidator`
  - `ReverseCardValidator`
  - `ShieldCardValidator`
  - `EvadeCardValidator`
  - `BonusCardValidator`
- 특수카드 공통 골격 추상화
  - `AbstractSpecialCardValidator` 도입
  - 공격 스택 여부에 따른 규칙 분기 + `sameSuit/sameValue` 공통 헬퍼 제공
- validator 선택 레지스트리 추가
  - `ActionValidator` 인터페이스
  - `ActionValidatorRegistry`
  - `ACTION_VALIDATORS` 토큰
- NestJS DI 연결
  - `GameModule`에 validator providers/registry 등록
  - `ACTION_VALIDATORS` 배열 주입 구성
- 테스트 대폭 보강
  - validator 단위 테스트 전체 추가
  - `AbstractSpecialCardValidator` 공통 동작 테스트 추가
  - `ActionValidatorRegistry` 선택/예외 테스트 추가
  - 특수카드 테스트 공통 fixture(`special-card-validator.spec.fixture.ts`) 도입

### 🧩 핵심 설계 포인트
1. **Template Method 기반 검증 파이프라인**
- `BaseActionValidator -> CardActionValidator -> Concrete Validator` 구조로 공통/개별 책임 분리
- 공통 검증 로직 중복 제거 및 카드별 규칙 변경 용이성 확보

2. **특수카드 규칙의 정책화**
- `AbstractSpecialCardValidator`에서 공통 골격을 고정
- 개별 특수카드는 `canPlayWhenAttackStack`, `canPlayWhenNoAttackStack` 정책만 구현
- 룰 변경 시 카드별 정책 메서드만 수정하면 되도록 설계

3. **Registry + DI로 확장성 확보**
- `supports(card)` 기반 validator 선택
- 신규 카드 액션 추가 시 validator class + module provider 등록만으로 확장 가능
- 서비스 로직에서 조건문 체인을 줄이고 책임을 validator로 위임하기 쉬운 구조

4. **테스트 구조화**
- 공통 fixture로 테스트 데이터 생성 중복 축소
- 공통 골격/카드별 정책 테스트를 분리해 가독성과 회귀 안정성 강화

### 테스트
- validator 계층 테스트 추가 및 통과
 
  <img width="560" height="270" alt="image" src="https://github.com/user-attachments/assets/b9281f28-60c3-416e-bd31-3f52cc2d26c4" />
 

### 체크리스트
- [x] 액션 검증 추상 인터페이스 정의
- [x] 카드별 validator 구현
- [x] 특수카드 공통 추상화 적용
- [x] registry 및 Nest DI 구성
- [x] 단위 테스트 작성 및 통과

closes ANI-10, ANI-22