### PR TITLE
refactor: move common card compare logic to CardActionValidator and r…

### DIFF
--- a/src/modules/game/validators/abstract-special-card.validator.ts
+++ b/src/modules/game/validators/abstract-special-card.validator.ts
@@ -61,18 +61,6 @@ export abstract class AbstractSpecialCardValidator extends CardActionValidator {
     }
   }
 
-  protected isSameSuit(
-    ctx: SpecialCardRuleContext,
-  ): boolean {
-    return ctx.lastCard.suit === ctx.card.suit;
-  }
-
-  protected isSameValue(
-    ctx: SpecialCardRuleContext,
-  ): boolean {
-    return ctx.lastCard.value === ctx.card.value;
-  }
-
   protected abstract canPlayWhenAttackStack(
     ctx: SpecialCardRuleContext,
   ): boolean;

--- a/src/modules/game/validators/bonus-card-action.validator.ts
+++ b/src/modules/game/validators/bonus-card-action.validator.ts
@@ -13,7 +13,7 @@ export class BonusCardValidator extends AbstractSpecialCardValidator {
   protected canPlayWhenNoAttackStack(
     ctx: SpecialCardRuleContext,
   ): boolean {
-    return this.isSameSuit(ctx);
+    return this.isSameSuit(ctx.lastCard, ctx.card);
   }
 
   protected getInvalidPlayMessage(): string {

--- a/src/modules/game/validators/card-action.validator.ts
+++ b/src/modules/game/validators/card-action.validator.ts
@@ -61,4 +61,18 @@ export abstract class CardActionValidator extends BaseActionValidator {
       );
     }
   }
+
+  protected isSameSuit(
+    first: Card,
+    second: Card,
+  ): boolean {
+    return first.suit === second.suit;
+  }
+
+  protected isSameValue(
+    first: Card,
+    second: Card,
+  ): boolean {
+    return first.value === second.value;
+  }
 }

--- a/src/modules/game/validators/evade-card-action.validator.ts
+++ b/src/modules/game/validators/evade-card-action.validator.ts
@@ -13,7 +13,16 @@ export class EvadeCardValidator extends AbstractSpecialCardValidator {
   protected canPlayWhenNoAttackStack(
     ctx: SpecialCardRuleContext,
   ): boolean {
-    return this.isSameSuit(ctx) || this.isSameValue(ctx);
+    return (
+      this.isSameSuit(
+        ctx.lastCard,
+        ctx.card,
+      ) ||
+      this.isSameValue(
+        ctx.lastCard,
+        ctx.card,
+      )
+    );
   }
 
   protected getInvalidPlayMessage(): string {

--- a/src/modules/game/validators/normal-card-action.validator.ts
+++ b/src/modules/game/validators/normal-card-action.validator.ts
@@ -38,10 +38,10 @@ export class NormalCardValidator extends CardActionValidator {
     }
 
     const isSameSuit =
-      lastCard.suit === card.suit;
+      this.isSameSuit(lastCard, card);
 
     const isSameValue =
-      lastCard.value === card.value;
+      this.isSameValue(lastCard, card);
 
     // 문양 또는 숫자가 같아야 함
     if (!isSameSuit && !isSameValue) {

--- a/src/modules/game/validators/reverse-card-action.validator.ts
+++ b/src/modules/game/validators/reverse-card-action.validator.ts
@@ -13,7 +13,16 @@ export class ReverseCardValidator extends AbstractSpecialCardValidator {
   protected canPlayWhenNoAttackStack(
     ctx: SpecialCardRuleContext,
   ): boolean {
-    return this.isSameSuit(ctx) || this.isSameValue(ctx);
+    return (
+      this.isSameSuit(
+        ctx.lastCard,
+        ctx.card,
+      ) ||
+      this.isSameValue(
+        ctx.lastCard,
+        ctx.card,
+      )
+    );
   }
 
   protected getInvalidPlayMessage(): string {

--- a/src/modules/game/validators/shield-card-action.validator.ts
+++ b/src/modules/game/validators/shield-card-action.validator.ts
@@ -13,7 +13,16 @@ export class ShieldCardValidator extends AbstractSpecialCardValidator {
   protected canPlayWhenNoAttackStack(
     ctx: SpecialCardRuleContext,
   ): boolean {
-    return this.isSameSuit(ctx) || this.isSameValue(ctx);
+    return (
+      this.isSameSuit(
+        ctx.lastCard,
+        ctx.card,
+      ) ||
+      this.isSameValue(
+        ctx.lastCard,
+        ctx.card,
+      )
+    );
   }
 
   protected getInvalidPlayMessage(): string {

--- a/src/modules/game/validators/skip-card-action.validator.ts
+++ b/src/modules/game/validators/skip-card-action.validator.ts
@@ -13,7 +13,16 @@ export class SkipCardValidator extends AbstractSpecialCardValidator {
   protected canPlayWhenNoAttackStack(
     ctx: SpecialCardRuleContext,
   ): boolean {
-    return this.isSameSuit(ctx) || this.isSameValue(ctx);
+    return (
+      this.isSameSuit(
+        ctx.lastCard,
+        ctx.card,
+      ) ||
+      this.isSameValue(
+        ctx.lastCard,
+        ctx.card,
+      )
+    );
   }
 
   protected getInvalidPlayMessage(): string {


### PR DESCRIPTION
`AbstractSpecialCardValidator`에 있던 공통된 카드로직(모양 비교, 값 비교)를 상위클래스 `CardActionValidator`에 이관하고,  `NormalCardValidator`에서 이를 재사용하게 하였습니다.