### PR TITLE
feat: [ANI-30] 와일드카드 대응

### DIFF
--- a/src/modules/game/game-setup.service.ts
+++ b/src/modules/game/game-setup.service.ts
@@ -43,6 +43,7 @@ export class GameSetupService {
   createCardPrototype(suit: CardSuit, type: CardType, value: string, power: number): Omit<Card, "id"> {
     return {
       suit,
+      declaredSuit: suit,
       type,
       value,
       power,

--- a/src/modules/game/game.service.spec.ts
+++ b/src/modules/game/game.service.spec.ts
@@ -484,6 +484,37 @@ describe('GameService (Unit)', () => {
 
       expect(room.turnOwner).toBe(host.userId);
     });
+
+    it('WILD 카드면 chosenSuit로 declaredSuit가 바뀌고 lastCard에 반영되어야 한다', () => {
+      const wildCard = createMockCard({
+        id: uuidv4(),
+        type: CardType.WILD,
+        value: 'WILD',
+        suit: CardSuit.RABBIT,
+        declaredSuit: CardSuit.RABBIT,
+      });
+
+      setHostCardForPlay(wildCard);
+
+      service.playCard(
+        host.userId,
+        wildCard.id,
+        CardSuit.CAT,
+      );
+
+      expect(wildCard.declaredSuit).toBe(CardSuit.CAT);
+      expect(room.lastCard?.id).toBe(wildCard.id);
+      expect(room.lastCard?.declaredSuit).toBe(CardSuit.CAT);
+      expect(
+        room.discardPile[room.discardPile.length - 1]
+          ?.declaredSuit,
+      ).toBe(CardSuit.CAT);
+      expect(validator.validate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          chosenSuit: CardSuit.CAT,
+        }),
+      );
+    });
   });
 });
 

--- a/src/modules/game/game.service.spec.ts
+++ b/src/modules/game/game.service.spec.ts
@@ -539,9 +539,11 @@ function mockUser() {
 }
 
 function createMockCard(overrides?: Partial<Card>): Card {
+  const suit = overrides?.suit ?? CardSuit.RABBIT;
   return {
     id: uuidv4(),
-    suit: CardSuit.RABBIT,
+    suit,
+    declaredSuit: overrides?.declaredSuit ?? suit,
     type: CardType.NUMBER,
     value: '1',
     power: 0,

--- a/src/modules/game/game.service.ts
+++ b/src/modules/game/game.service.ts
@@ -258,7 +258,7 @@ export class GameService {
           break;
       }
     } else if (card.type === CardType.WILD) {
-      // TODO (ANI-30)
+      // Wild는 suit 선언만 변경하고 턴/보너스 상태만 일반 진행으로 정리한다.
       room.isBonusTurn = false;
     } else {
       room.isBonusTurn = false;

--- a/src/modules/game/game.service.ts
+++ b/src/modules/game/game.service.ts
@@ -2,7 +2,7 @@ import { Card, GameRoom, Player } from "src/shared/interfaces/game.interface";
 import { GameSetupService } from "./game-setup.service";
 import { RoomService } from "../socket/room.service";
 import { WsException } from "@nestjs/websockets";
-import { CardType, GameDirection } from "../../shared/enums/game.enum";
+import { CardSuit, CardType, GameDirection } from "../../shared/enums/game.enum";
 import { LogType } from "src/shared/enums/log.enum";
 import { Injectable } from "@nestjs/common";
 import { ActionValidatorRegistry } from "./validators/action-validator.registry";
@@ -145,6 +145,7 @@ export class GameService {
   playCard(
     userId: string,
     cardId: string,
+    chosenSuit?: CardSuit,
   ): GameRoom {
     const room = this.getValidRoom(userId);
     const player = this.getPlayablePlayer(room, userId);
@@ -157,7 +158,12 @@ export class GameService {
       room,
       player,
       card,
+      chosenSuit,
     });
+
+    if (card.type === CardType.WILD) {
+      card.declaredSuit = chosenSuit!;
+    }
 
     player.hand = player.hand.filter(
       (handCard) => handCard.id !== card.id,

--- a/src/modules/game/validators/action-validator.registry.spec.ts
+++ b/src/modules/game/validators/action-validator.registry.spec.ts
@@ -12,15 +12,19 @@ import { ActionValidatorRegistry } from './action-validator.registry';
 describe('ActionValidatorRegistry', () => {
   const createMockCard = (
     overrides: Partial<Card> = {},
-  ): Card => ({
-    id: 'card-1',
-    suit: CardSuit.RABBIT,
-    value: 'JUMP',
-    type: CardType.SPECIAL,
-    power: 0,
-    assetKey: 'rabbit_jump',
-    ...overrides,
-  });
+  ): Card => {
+    const suit = overrides.suit ?? CardSuit.RABBIT;
+    return {
+      id: 'card-1',
+      suit,
+      declaredSuit: overrides.declaredSuit ?? suit,
+      value: 'JUMP',
+      type: CardType.SPECIAL,
+      power: 0,
+      assetKey: 'rabbit_jump',
+      ...overrides,
+    };
+  };
 
   const createMockValidator = (
     supportsValue: boolean,

--- a/src/modules/game/validators/attack-card-action.validator.spec.ts
+++ b/src/modules/game/validators/attack-card-action.validator.spec.ts
@@ -23,15 +23,19 @@ describe('AttackCardValidator', () => {
 
   const createMockCard = (
     overrides: Partial<Card> = {},
-  ): Card => ({
-    id: 'card-1',
-    suit: CardSuit.RABBIT,
-    value: 'SWORD_2',
-    type: CardType.ATTACK,
-    power: 2,
-    assetKey: 'rabbit_sword_2',
-    ...overrides,
-  });
+  ): Card => {
+    const suit = overrides.suit ?? CardSuit.RABBIT;
+    return {
+      id: 'card-1',
+      suit,
+      declaredSuit: overrides.declaredSuit ?? suit,
+      value: 'SWORD_2',
+      type: CardType.ATTACK,
+      power: 2,
+      assetKey: 'rabbit_sword_2',
+      ...overrides,
+    };
+  };
 
   const createMockPlayer = (
     overrides: Partial<Player> = {},

--- a/src/modules/game/validators/base-action.validator.spec.ts
+++ b/src/modules/game/validators/base-action.validator.spec.ts
@@ -27,15 +27,19 @@ describe('BaseActionValidator', () => {
     validator = new TestValidator();
   });
 
-  const createMockCard = (overrides: Partial<Card> = {}) => ({
-    id: 'card-1',
-    suit: CardSuit.RABBIT,
-    value: '1',
-    type: CardType.NUMBER,
-    power: 0,
-    assetKey: 'rabbit_1',
-    ...overrides,
-  });
+  const createMockCard = (overrides: Partial<Card> = {}) => {
+    const suit = overrides.suit ?? CardSuit.RABBIT;
+    return {
+      id: 'card-1',
+      suit,
+      declaredSuit: overrides.declaredSuit ?? suit,
+      value: '1',
+      type: CardType.NUMBER,
+      power: 0,
+      assetKey: 'rabbit_1',
+      ...overrides,
+    };
+  };
 
   const createMockPlayer = (overrides: Partial<Player> = {}) => ({
     userId: 'user-1',

--- a/src/modules/game/validators/card-action.validator.spec.ts
+++ b/src/modules/game/validators/card-action.validator.spec.ts
@@ -37,6 +37,7 @@ describe('CardActionValidator', () => {
   const createMockCard = (overrides: Partial<Card> = {}): Card => ({
     id: 'card-1',
     suit: CardSuit.RABBIT,
+    declaredSuit: overrides.declaredSuit ?? overrides.suit ?? CardSuit.RABBIT,
     value: '1',
     type: CardType.NUMBER,
     power: 0,

--- a/src/modules/game/validators/card-action.validator.ts
+++ b/src/modules/game/validators/card-action.validator.ts
@@ -1,6 +1,10 @@
 import { WsException } from '@nestjs/websockets';
 
 import {
+  CardSuit,
+} from 'src/shared/enums/game.enum';
+
+import {
   Card,
   GameRoom,
   Player,
@@ -9,6 +13,7 @@ import { BaseActionValidator, ValidateActionParams } from './base-action.validat
 
 export interface ValidateCardActionParams extends ValidateActionParams {
   card: Card;
+  chosenSuit?: CardSuit;
 }
 
 /**
@@ -66,7 +71,7 @@ export abstract class CardActionValidator extends BaseActionValidator {
     first: Card,
     second: Card,
   ): boolean {
-    return first.suit === second.suit;
+    return first.declaredSuit === second.declaredSuit;
   }
 
   protected isSameValue(

--- a/src/modules/game/validators/normal-card-action.validator.spec.ts
+++ b/src/modules/game/validators/normal-card-action.validator.spec.ts
@@ -22,15 +22,19 @@ describe('NormalCardValidator', () => {
 
   const createMockCard = (
     overrides: Partial<Card> = {},
-  ): Card => ({
-    id: 'card-1',
-    suit: CardSuit.RABBIT,
-    value: '1',
-    type: CardType.NUMBER,
-    power: 0,
-    assetKey: 'rabbit_1',
-    ...overrides,
-  });
+  ): Card => {
+    const suit = overrides.suit ?? CardSuit.RABBIT;
+    return {
+      id: 'card-1',
+      suit,
+      declaredSuit: overrides.declaredSuit ?? suit,
+      value: '1',
+      type: CardType.NUMBER,
+      power: 0,
+      assetKey: 'rabbit_1',
+      ...overrides,
+    };
+  };
 
   const createMockPlayer = (
     overrides: Partial<Player> = {},

--- a/src/modules/game/validators/special-card-validator.spec.fixture.ts
+++ b/src/modules/game/validators/special-card-validator.spec.fixture.ts
@@ -15,15 +15,19 @@ export function createSpecialValidatorFixtures(
 ) {
   const createMockCard = (
     overrides: Partial<Card> = {},
-  ): Card => ({
-    id: 'card-1',
-    suit: CardSuit.RABBIT,
-    value: specialValue,
-    type: CardType.SPECIAL,
-    power: 0,
-    assetKey,
-    ...overrides,
-  });
+  ): Card => {
+    const suit = overrides.suit ?? CardSuit.RABBIT;
+    return {
+      id: 'card-1',
+      suit,
+      declaredSuit: overrides.declaredSuit ?? suit,
+      value: specialValue,
+      type: CardType.SPECIAL,
+      power: 0,
+      assetKey,
+      ...overrides,
+    };
+  };
 
   const createMockPlayer = (
     overrides: Partial<Player> = {},

--- a/src/modules/game/validators/wildcard-action.validator.spec.ts
+++ b/src/modules/game/validators/wildcard-action.validator.spec.ts
@@ -22,15 +22,19 @@ describe('WildcardActionValidator', () => {
 
   const createMockCard = (
     overrides: Partial<Card> = {},
-  ): Card => ({
-    id: 'card-1',
-    suit: CardSuit.RABBIT,
-    value: 'WILD',
-    type: CardType.WILD,
-    power: 0,
-    assetKey: 'rabbit_wild',
-    ...overrides,
-  });
+  ): Card => {
+    const suit = overrides.suit ?? CardSuit.RABBIT;
+    return {
+      id: 'card-1',
+      suit,
+      declaredSuit: overrides.declaredSuit ?? suit,
+      value: 'WILD',
+      type: CardType.WILD,
+      power: 0,
+      assetKey: 'rabbit_wild',
+      ...overrides,
+    };
+  };
 
   const createMockPlayer = (
     overrides: Partial<Player> = {},
@@ -118,6 +122,7 @@ describe('WildcardActionValidator', () => {
           room: room as GameRoom,
           player,
           card,
+          chosenSuit: CardSuit.BEAR,
         }),
       ).toThrow(WsException);
     });
@@ -148,6 +153,7 @@ describe('WildcardActionValidator', () => {
           room: room as GameRoom,
           player,
           card,
+          chosenSuit: CardSuit.RABBIT,
         }),
       ).toThrow();
     });
@@ -168,6 +174,7 @@ describe('WildcardActionValidator', () => {
           room: room as GameRoom,
           player,
           card,
+          chosenSuit: CardSuit.BEAR,
         }),
       ).not.toThrow();
     });
@@ -196,6 +203,7 @@ describe('WildcardActionValidator', () => {
           room: room as GameRoom,
           player,
           card,
+          chosenSuit: CardSuit.RABBIT,
         }),
       ).toThrow(WsException);
     });

--- a/src/modules/game/validators/wildcard-action.validator.ts
+++ b/src/modules/game/validators/wildcard-action.validator.ts
@@ -19,7 +19,13 @@ export class WildcardActionValidator extends CardActionValidator {
   protected validateRule(
     params: ValidateCardActionParams,
   ): void {
-    const { room, card } = params;
+    const { room, card, chosenSuit } = params;
+
+    if (!chosenSuit) {
+      throw new WsException(
+        'Wildcard requires chosenSuit',
+      );
+    }
 
     if (!room.lastCard) {
       throw new WsException(

--- a/src/modules/socket/dto/game-room.dto.ts
+++ b/src/modules/socket/dto/game-room.dto.ts
@@ -1,4 +1,5 @@
-import { IsBoolean, IsDefined, IsNotEmpty, IsString, IsUUID } from "class-validator";
+import { IsBoolean, IsDefined, IsEnum, IsNotEmpty, IsOptional, IsString, IsUUID } from "class-validator";
+import { CardSuit } from "src/shared/enums/game.enum";
 
 export class RoomIdDto {
   @IsUUID('4', { message: '방 ID는 유효한 UUID v4 형식이어야 합니다.' })
@@ -17,4 +18,8 @@ export class PlayCardDto extends RoomIdDto {
   @IsUUID('4', { message: '카드 ID는 유효한 UUID v4 형식이어야 합니다.' })
   @IsNotEmpty({ message: '낼 카드의 ID가 필요합니다.' })
   cardId!: string;
+
+  @IsOptional()
+  @IsEnum(CardSuit, { message: 'chosenSuit는 유효한 CardSuit여야 합니다.' })
+  chosenSuit?: CardSuit;
 }

--- a/src/modules/socket/dto/game-room.response.dto.spec.ts
+++ b/src/modules/socket/dto/game-room.response.dto.spec.ts
@@ -43,9 +43,11 @@ describe('GameRoomResponseDto', () => {
 });
 
 function createMockCard(overrides?: Partial<Card>): Card {
+  const suit = overrides?.suit ?? CardSuit.RABBIT;
   return {
     id: uuidv4(),
-    suit: CardSuit.RABBIT,
+    suit,
+    declaredSuit: overrides?.declaredSuit ?? suit,
     type: CardType.NUMBER,
     value: '1',
     power: 0,

--- a/src/modules/socket/dto/play-card.dto.spec.ts
+++ b/src/modules/socket/dto/play-card.dto.spec.ts
@@ -36,4 +36,29 @@ describe('PlayCardDto', () => {
     expect(errors.length).toBeGreaterThan(0);
     expect(errors[0].property).toBe('cardId');
   });
+
+  it('chosenSuit가 유효한 CardSuit면 통과해야 한다', async () => {
+    const target = {
+      roomId: '550e8400-e29b-41d4-a716-446655440000',
+      cardId: '770e8400-e29b-41d4-a716-446655441111',
+      chosenSuit: 'CAT',
+    };
+    const dto = plainToInstance(PlayCardDto, target);
+    const errors = await validate(dto);
+
+    expect(errors.length).toBe(0);
+  });
+
+  it('chosenSuit가 유효하지 않으면 실패해야 한다', async () => {
+    const target = {
+      roomId: '550e8400-e29b-41d4-a716-446655440000',
+      cardId: '770e8400-e29b-41d4-a716-446655441111',
+      chosenSuit: 'INVALID',
+    };
+    const dto = plainToInstance(PlayCardDto, target);
+    const errors = await validate(dto);
+
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].property).toBe('chosenSuit');
+  });
 });

--- a/src/modules/socket/game.gateway.spec.ts
+++ b/src/modules/socket/game.gateway.spec.ts
@@ -47,6 +47,7 @@ describe('GameGateway', () => {
           type: CardType.NUMBER,
           power: 0,
           suit: CardSuit.RABBIT,
+          declaredSuit: CardSuit.RABBIT,
           value: '3',
           assetKey: 'rabbit_3',
         }
@@ -74,6 +75,7 @@ describe('GameGateway', () => {
       expect(gameService.playCard).toHaveBeenCalledWith(
         'user-1',
         'card-1',
+        undefined,
       );
       expect(to).toHaveBeenCalledWith(
         'room-1',

--- a/src/modules/socket/game.gateway.ts
+++ b/src/modules/socket/game.gateway.ts
@@ -138,6 +138,7 @@ export class GameGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
     const updatedRoom = this.gameService.playCard(
       client.data.user.userId,
       data.cardId,
+      data.chosenSuit,
     );
 
     this.server

--- a/src/modules/socket/masking.service.spec.ts
+++ b/src/modules/socket/masking.service.spec.ts
@@ -126,9 +126,11 @@ describe('MaskingService', () => {
 });
 
 function createMockCard(overrides?: Partial<Card>): Card {
+  const suit = overrides?.suit ?? CardSuit.RABBIT;
   return {
     id: uuidv4(),
-    suit: CardSuit.RABBIT,
+    suit,
+    declaredSuit: overrides?.declaredSuit ?? suit,
     type: CardType.NUMBER,
     value: '1',
     power: 0,

--- a/src/shared/interfaces/game.interface.ts
+++ b/src/shared/interfaces/game.interface.ts
@@ -4,6 +4,7 @@ import { GameLog } from './log.interface';
 export interface Card {
   id: string;
   suit: CardSuit;
+  declaredSuit: CardSuit;
   type: CardType;
   value: string;      // "1"~"10", "SWORD_1~3", "SHIELD", "EVADE", "BONUS"
   power: number;      // 공격 시 칼 자루 수 (1~3), 그 외 0


### PR DESCRIPTION
## 작업 개요

와일드카드가 단순히 `WILD` 타입 카드로만 존재하는 수준을 넘어서, **플레이 시점에 바닥 카드의 모양을 새로 선언하고 이후 판정에 반영되도록** 게임 로직과 데이터 모델을 확장했습니다.

이번 작업은 다음 두 가지를 함께 해결하는 데 초점을 맞췄습니다.

1. 와일드카드가 "현재 어떤 모양으로 선언되어 있는 카드인지" 상태로 남도록 모델링
2. 클라이언트 입력, 서버 검증, 후속 카드 판정이 모두 그 선언값을 기준으로 일관되게 동작하도록 연결

---

## 🚀 주요 변경사항

### 1. 카드 모델 확장
`Card` 인터페이스에 `declaredSuit`를 추가했습니다.

- `suit`: 카드의 원래 소속 동물 모양
- `declaredSuit`: 현재 게임 판정에 사용되는 선언 모양

일반 카드와 특수 카드는 기본적으로 `declaredSuit === suit` 상태를 유지하고, 와일드카드는 플레이 시점에만 `declaredSuit`가 바뀔 수 있도록 설계했습니다.

### 2. 마스터 덱 생성 시 기본 선언값 초기화
`createCardPrototype`에서 모든 카드의 `declaredSuit`를 기본적으로 `suit`와 동일하게 초기화했습니다.

이렇게 해서:
- 기존 카드 판정 로직과 자연스럽게 호환되고
- 와일드카드만 예외적으로 선언값을 덮어쓰는 구조를 만들었습니다.

### 3. `playCard` 입력 확장
`playCard(userId, cardId, chosenSuit?)` 형태로 확장하고, 소켓 DTO(`PlayCardDto`)와 gateway까지 `chosenSuit`를 전달하도록 연결했습니다.

클라이언트는 와일드카드를 낼 때 선언할 모양을 함께 보내고, 서버는 해당 값을 검증 후 실제 카드 상태에 반영합니다.

### 4. 카드 문양 비교 기준 변경
`CardActionValidator.isSameSuit`가 기존 `suit` 비교에서 `declaredSuit` 비교로 바뀌었습니다.

이 변경으로 인해:
- 와일드카드가 선언한 모양이 이후 턴의 유효성 판정에 직접 반영되고
- 각 카드별 validator는 별도 예외 처리 없이도 동일한 비교 기준을 공유하게 됩니다.

### 5. 와일드카드 전용 검증 추가
`WildcardActionValidator`에서 `chosenSuit` 존재 여부를 검증하도록 보강했습니다.

즉, 와일드카드는:
- 공격 스택 중에는 사용할 수 없고
- 바닥 카드가 있어야 하며
- `chosenSuit`가 반드시 들어와야 하고
- 현재 규칙상 바닥 카드와의 매칭 조건도 만족해야 합니다.

---

## 🧩 핵심 설계 포인트

### 선언 상태와 카드 원형 상태를 분리
와일드카드는 "무슨 카드인가"와 "지금 어떤 모양으로 취급되는가"가 다릅니다.  
이를 `suit`와 `declaredSuit`로 분리해 표현하면서, 카드의 정체성과 현재 판정 상태를 명확히 나눴습니다.

이 방식의 장점:
- 원본 카드 정보 보존
- 와일드카드 효과를 별도 상태 객체 없이 카드 자체에 귀속
- 후속 validator에서 동일한 비교 로직 재사용 가능

### 판정 기준을 공통 validator 계층으로 끌어올림
문양 비교를 개별 validator마다 수정하지 않고, `CardActionValidator.isSameSuit`에서 한 번에 `declaredSuit` 기준으로 전환했습니다.

이 덕분에:
- 일반 카드, 공격 카드, 특수 카드 validator 전반이 같은 규칙을 따르고
- 와일드카드 도입에 따른 규칙 변경 범위를 최소화할 수 있었습니다.

### 입력은 optional, 규칙은 카드 타입별로 엄격하게
DTO의 `chosenSuit`는 전체 `playCard` 이벤트 관점에서는 optional로 두고, 실제 필수 여부는 와일드카드 validator가 책임지도록 구성했습니다.

이 설계는:
- 일반 카드 플레이 요청에는 불필요한 입력을 강제하지 않고
- 와일드카드에만 타입별 규칙을 적용할 수 있게 해줍니다.

---

## 테스트

다음 범위를 함께 보강했습니다.

- `PlayCardDto`의 `chosenSuit` 유효성 검사
- gateway에서 `chosenSuit` 전달 여부
- 와일드카드 validator의 `chosenSuit` 필수 조건
- `declaredSuit` 도입에 맞춘 테스트 헬퍼 전반 정리
- 기존 validator 스펙이 새 문양 비교 기준에서도 일관되게 동작하는지 확인

---

## 기대 효과

이번 변경으로 와일드카드는 단순 특수카드가 아니라, **플레이어가 선언한 모양을 실제 게임 상태로 남기고 다음 턴 판정까지 이어지는 카드**로 동작하게 됩니다.

이후 로그, UI 표시, 상태 복구(F5), 리플레이 같은 기능을 붙일 때도 `declaredSuit`를 기준으로 현재 카드 상태를 안정적으로 해석할 수 있습니다.

closes ANI-30