### PR TITLE
feat: [ANI-31] 드로우 액션 & 바닥 덱 섞기

### DIFF
--- a/src/modules/game/game.service.spec.ts
+++ b/src/modules/game/game.service.spec.ts
@@ -516,6 +516,147 @@ describe('GameService (Unit)', () => {
       );
     });
   });
+
+  describe('drawCard', () => {
+    let guest: ReturnType<typeof mockUser>;
+    let drawnCard: Card;
+
+    beforeEach(() => {
+      guest = mockUser();
+      room.players.push(createPlayer(guest, true));
+
+      room.status = 'PLAYING';
+      room.turnOwner = host.userId;
+      room.direction = GameDirection.CLOCKWISE;
+      room.lastActionId = 0;
+
+      drawnCard = createMockCard({
+        id: uuidv4(),
+        suit: CardSuit.CAT,
+        type: CardType.NUMBER,
+        value: '3',
+      });
+
+      room.drawPile = [drawnCard];
+      room.players[0].hand = [];
+      room.players[0].cardCount = 0;
+
+      roomService.getNextTurnOwner.mockImplementation(
+        (targetRoom, currentUserId) => {
+          const activePlayers = targetRoom.players.filter(
+            (p) => p.role === 'PLAYER' && !p.isOut,
+          );
+
+          if (activePlayers.length === 1) {
+            return activePlayers[0].userId;
+          }
+
+          const index = activePlayers.findIndex(
+            (p) => p.userId === currentUserId,
+          );
+          const nextIndex =
+            (index + targetRoom.direction + activePlayers.length) %
+            activePlayers.length;
+
+          return activePlayers[nextIndex].userId;
+        },
+      );
+    });
+
+    it('drawPile의 맨 앞 카드를 호출한 플레이어 hand에 추가하고 턴/액션/로그를 갱신해야 한다', () => {
+      const updatedRoom = service.drawCard(
+        host.userId,
+        room.roomId,
+      );
+
+      const updatedHost = updatedRoom.players.find(
+        p => p.userId === host.userId,
+      )!;
+
+      expect(updatedHost.hand).toEqual([drawnCard]);
+      expect(updatedHost.cardCount).toBe(1);
+      expect(updatedRoom.drawPile).toEqual([]);
+      expect(updatedRoom.turnOwner).toBe(guest.userId);
+      expect(updatedRoom.lastActionId).toBe(1);
+      expect(roomService.pushLog).toHaveBeenCalledWith(
+        updatedRoom,
+        expect.objectContaining({
+          type: LogType.DRAW,
+          actorId: host.userId,
+          actorName: host.nickname,
+          cardId: drawnCard.id,
+        }),
+      );
+    });
+
+    it('요청 roomId가 서버 세션의 roomId와 다르면 예외가 발생해야 한다', () => {
+      expect(() =>
+        service.drawCard(host.userId, uuidv4()),
+      ).toThrow(
+        new WsException('Room ID does not match the user session'),
+      );
+    });
+
+    it('drawPile이 비었으면 lastCard를 제외한 discardPile을 셔플해 재사용하고 그 카드로 드로우해야 한다', () => {
+      const lastCard = createMockCard({
+        id: uuidv4(),
+        suit: CardSuit.RABBIT,
+        value: '9',
+      });
+      const recycledCardA = createMockCard({
+        id: uuidv4(),
+        suit: CardSuit.CAT,
+        value: '2',
+      });
+      const recycledCardB = createMockCard({
+        id: uuidv4(),
+        suit: CardSuit.DOG,
+        value: '4',
+      });
+
+      room.lastCard = lastCard;
+      room.drawPile = [];
+      room.discardPile = [recycledCardA, recycledCardB, lastCard];
+
+      let shuffledInput: Card[] = [];
+      gameSetupService.shuffle.mockImplementation((deck) => {
+        shuffledInput = [...deck];
+        deck.reverse();
+      });
+
+      const updatedRoom = service.drawCard(
+        host.userId,
+        room.roomId,
+      );
+      const updatedHost = updatedRoom.players.find(
+        p => p.userId === host.userId,
+      )!;
+
+      expect(shuffledInput).toEqual([
+        recycledCardA,
+        recycledCardB,
+      ]);
+      expect(updatedHost.hand).toEqual([recycledCardB]);
+      expect(updatedHost.cardCount).toBe(1);
+      expect(updatedRoom.drawPile).toEqual([recycledCardA]);
+      expect(updatedRoom.discardPile).toEqual([lastCard]);
+      expect(updatedRoom.lastCard).toBe(lastCard);
+      expect(roomService.createSystemLog).toHaveBeenCalledWith(
+        updatedRoom,
+        host.userId,
+        LogType.NOTICE,
+        '드로우할 카드가 없어 버린 패를 다시 섞습니다.',
+      );
+      expect(roomService.pushLog).toHaveBeenCalledWith(
+        updatedRoom,
+        expect.objectContaining({
+          type: LogType.DRAW,
+          actorId: host.userId,
+          cardId: recycledCardB.id,
+        }),
+      );
+    });
+  });
 });
 
 // helper functions for tests

--- a/src/modules/game/game.service.ts
+++ b/src/modules/game/game.service.ts
@@ -179,6 +179,69 @@ export class GameService {
     return room;
   }
 
+  drawCard(
+    userId: string,
+    roomId: string,
+  ): GameRoom {
+    const room = this.getValidRoom(userId);
+
+    if (room.roomId !== roomId) {
+      throw new WsException('Room ID does not match the user session');
+    }
+
+    const player = this.getPlayablePlayer(room, userId);
+    this.refillDrawPileFromDiscardPile(room, userId);
+    const card = room.drawPile.shift();
+
+    if (!card) {
+      throw new WsException('No cards left in draw pile');
+    }
+
+    player.hand.push(card);
+    player.cardCount = player.hand.length;
+    room.turnOwner = this.roomService.getNextTurnOwner(
+      room,
+      player.userId,
+    );
+    room.lastActionId += 1;
+    this.pushDrawCardLog(room, player, card);
+
+    return room;
+  }
+
+  private refillDrawPileFromDiscardPile(
+    room: GameRoom,
+    actorId: string,
+  ): void {
+    if (room.drawPile.length > 0) {
+      return;
+    }
+
+    const lastCardId = room.lastCard?.id;
+    const recyclableCards = room.discardPile.filter(
+      (card) => card.id !== lastCardId,
+    );
+
+    if (recyclableCards.length === 0) {
+      return;
+    }
+
+    this.roomService.pushLog(
+      room,
+      this.roomService.createSystemLog(
+        room,
+        actorId,
+        LogType.NOTICE,
+        '드로우할 카드가 없어 버린 패를 다시 섞습니다.',
+      ),
+    );
+    this.gameSetupService.shuffle(recyclableCards);
+    room.drawPile = recyclableCards;
+    room.discardPile = room.lastCard
+      ? [room.lastCard]
+      : [];
+  }
+
   private getPlayablePlayer(
     room: GameRoom,
     userId: string,
@@ -303,6 +366,23 @@ export class GameService {
     if (card.type === CardType.ATTACK && room.turnOwner) {
       log.targetId = room.turnOwner;
     }
+
+    this.roomService.pushLog(room, log);
+  }
+
+  private pushDrawCardLog(
+    room: GameRoom,
+    player: Player,
+    card: Card,
+  ): void {
+    const log: GameLog = {
+      id: uuidv4(),
+      type: LogType.DRAW,
+      actorId: player.userId,
+      actorName: player.nickname,
+      cardId: card.id,
+      timestamp: Date.now(),
+    };
 
     this.roomService.pushLog(room, log);
   }

--- a/src/modules/socket/game.gateway.spec.ts
+++ b/src/modules/socket/game.gateway.spec.ts
@@ -1,5 +1,7 @@
 import { createMock } from '@golevelup/ts-jest';
+import { GUARDS_METADATA, INTERCEPTORS_METADATA } from '@nestjs/common/constants';
 import { WsException } from '@nestjs/websockets';
+import { MESSAGE_MAPPING_METADATA, MESSAGE_METADATA } from '@nestjs/websockets/constants';
 import { Server, Socket } from 'socket.io';
 
 import { AuthService } from '../auth/auth.service';
@@ -11,6 +13,9 @@ import { GameRoom } from 'src/shared/interfaces/game.interface';
 import { CardSuit, CardType, GameDirection } from 'src/shared/enums/game.enum';
 import { SocketData } from 'socket.io';
 import { v4 as uuidv4 } from 'uuid';
+import { GameParticipantGuard } from 'src/common/guards/game-participant.guard';
+import { TurnOwnerGuard } from 'src/common/guards/turnowner.guard';
+import { GameResponseInterceptor } from './interceptors/game-response.interceptor';
 
 describe('GameGateway', () => {
   let gateway: GameGateway;
@@ -123,6 +128,146 @@ describe('GameGateway', () => {
           },
         ),
       ).toThrow(WsException);
+    });
+  });
+
+  describe('handleDrawCard', () => {
+    it('drawCard 이벤트에서 GameService.drawCard를 호출해야 한다', () => {
+      const client = {
+        data: {
+          user: {
+            userId: 'user-1',
+            nickname: 'tester',
+            isGuest: false,
+          },
+        },
+      } as Socket;
+
+      const updatedRoom: Partial<GameRoom> = {
+        roomId: 'room-1',
+      };
+
+      gameService.drawCard.mockReturnValue(
+        updatedRoom as GameRoom,
+      );
+
+      const emit = jest.fn();
+      const to = jest.fn().mockReturnValue({
+        emit,
+      });
+
+      gateway.server = { to } as unknown as Server;
+
+      const result = gateway.handleDrawCard(
+        client,
+        {
+          roomId: 'room-1',
+        },
+      );
+
+      expect(gameService.drawCard).toHaveBeenCalledWith(
+        'user-1',
+        'room-1',
+      );
+      expect(to).toHaveBeenCalledWith(
+        'room-1',
+      );
+      expect(emit).toHaveBeenCalledWith(
+        SocketEvent.GAME_STATE_UPDATE,
+        {
+          message: `${client.data.user.nickname}님이 카드를 한 장 뽑았습니다.`,
+        },
+      );
+      expect(result).toBe(updatedRoom);
+    });
+
+    it('서비스에서 발생한 예외를 그대로 전파해야 한다', () => {
+      const client = {
+        data: {
+          user: {
+            userId: 'user-1',
+            nickname: 'tester',
+            isGuest: false,
+          },
+        },
+      } as Socket;
+
+      gameService.drawCard.mockImplementation(
+        () => {
+          throw new WsException('draw card failed');
+        },
+      );
+
+      gateway.server = {
+        to: jest.fn().mockReturnValue({
+          emit: jest.fn(),
+        }),
+      } as unknown as Server;
+
+      expect(() =>
+        gateway.handleDrawCard(
+          client,
+          {
+            roomId: 'room-1',
+          },
+        ),
+      ).toThrow(WsException);
+    });
+
+    it('payload roomId를 GameService.drawCard로 전달해야 한다', () => {
+      const client = {
+        data: {
+          user: {
+            userId: 'user-1',
+            nickname: 'tester',
+            isGuest: false,
+          },
+        },
+      } as Socket;
+
+      gameService.drawCard.mockReturnValue({
+        roomId: 'room-other',
+      } as GameRoom);
+
+      gateway.server = {
+        to: jest.fn().mockReturnValue({
+          emit: jest.fn(),
+        }),
+      } as unknown as Server;
+
+      gateway.handleDrawCard(
+        client,
+        {
+          roomId: 'room-other',
+        },
+      );
+
+      expect(gameService.drawCard).toHaveBeenCalledWith(
+        'user-1',
+        'room-other',
+      );
+    });
+
+    it('GameParticipantGuard와 TurnOwnerGuard, GameResponseInterceptor가 적용되어야 한다', () => {
+      const handler = GameGateway.prototype.handleDrawCard;
+
+      expect(
+        Reflect.getMetadata(MESSAGE_MAPPING_METADATA, handler),
+      ).toBe(true);
+      expect(
+        Reflect.getMetadata(MESSAGE_METADATA, handler),
+      ).toBe(SocketEvent.DRAW_CARD);
+      expect(
+        Reflect.getMetadata(GUARDS_METADATA, handler),
+      ).toEqual([
+        GameParticipantGuard,
+        TurnOwnerGuard,
+      ]);
+      expect(
+        Reflect.getMetadata(INTERCEPTORS_METADATA, handler),
+      ).toEqual([
+        GameResponseInterceptor,
+      ]);
     });
   });
 });

--- a/src/modules/socket/game.gateway.ts
+++ b/src/modules/socket/game.gateway.ts
@@ -11,7 +11,7 @@ import {
 } from '@nestjs/websockets';
 import { Logger, UseFilters, UseGuards, UseInterceptors, UsePipes, ValidationPipe } from '@nestjs/common';
 import { Server, Socket, SocketData } from 'socket.io';
-import { JoinRoomDto, PlayCardDto } from './dto/game-room.dto';
+import { JoinRoomDto, PlayCardDto, RoomIdDto } from './dto/game-room.dto';
 import { SocketEvent } from 'src/shared/enums/socket-event.enum';
 import { SocketAuthMiddleware } from './middlewares/auth.middleware';
 import { WsExceptionFilter } from 'src/common/filters/ws-exception.filter';
@@ -147,6 +147,34 @@ export class GameGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
         SocketEvent.GAME_STATE_UPDATE,
         {
           message: `${client.data.user.nickname}님이 [${updatedRoom.lastCard?.suit} ${updatedRoom.lastCard?.value}] 카드를 냈습니다.`,
+        }
+      );
+
+    return updatedRoom;
+  }
+
+  @UseGuards(GameParticipantGuard, TurnOwnerGuard)
+  @UseInterceptors(GameResponseInterceptor)
+  @SubscribeMessage(SocketEvent.DRAW_CARD)
+  handleDrawCard(
+    @ConnectedSocket() client: Socket,
+    @MessageBody() data: RoomIdDto,
+  ) {
+    this.logger.log(
+      `[${SocketEvent.DRAW_CARD}] 유저 ${client.data.user.nickname}(${client.data.user.userId})가 방(${data.roomId})에서 카드 드로우 시도`
+    );
+
+    const updatedRoom = this.gameService.drawCard(
+      client.data.user.userId,
+      data.roomId,
+    );
+
+    this.server
+      .to(updatedRoom.roomId)
+      .emit(
+        SocketEvent.GAME_STATE_UPDATE,
+        {
+          message: `${client.data.user.nickname}님이 카드를 한 장 뽑았습니다.`,
         }
       );
 


### PR DESCRIPTION
## 📌 개요
게임 중 플레이어가 카드를 뽑는 `drawCard` 액션을 서버에 추가했습니다.  
드로우는 단순 카드 이동에 그치지 않고 턴 진행, 액션 카운터 증가, 로그 기록까지 하나의 게임 액션으로 처리되도록 정리했습니다.

또한 `drawPile`이 소진된 경우, 바닥에 놓인 마지막 카드(`lastCard`)를 제외한 `discardPile`을 다시 섞어 드로우 덱으로 재사용하는 로직을 함께 추가했습니다.

## ✅ 주요 작업
- `GameService.drawCard(userId, roomId)` 구현
- `DRAW_CARD` WebSocket 핸들러 추가
- `drawCard`에 `GameParticipantGuard`, `TurnOwnerGuard`, `GameResponseInterceptor` 적용
- 드로우 후 다음 턴으로 넘기는 처리 추가
- 드로우 액션 시 `lastActionId += 1` 반영
- `LogType.DRAW` 기반 드로우 로그 기록 추가
- `drawPile` 소진 시 `discardPile` 재셔플 로직 추가
- 재셔플 발생 시 시스템 안내 로그 추가
- 단위 테스트 및 게이트웨이 테스트 보강

## 🧭 핵심 설계 포인트
### 1. drawCard를 독립적인 게임 액션으로 취급
`drawCard`는 카드 한 장을 hand에 넣는 수준이 아니라,
- 턴 소유자 변경
- 액션 ID 증가
- 로그 적재

까지 함께 처리되도록 구성했습니다.  
이를 통해 `playCard`와 유사한 수준의 상태 일관성을 유지합니다.

### 2. 룸 검증 책임은 서비스에 배치
Gateway는 이벤트 진입점으로만 두고,  
`roomId`와 실제 세션의 방 일치 여부 검증은 `GameService.drawCard` 내부에서 수행하도록 정리했습니다.

이렇게 해서:
- Gateway는 얇게 유지
- drawCard 관련 비즈니스 규칙은 서비스에 집중
- 이후 다른 진입 경로가 생겨도 동일 규칙 재사용 가능

한 구조를 유지했습니다.

### 3. reshuffle 시 `lastCard`는 항상 바닥에 유지
`drawPile`이 비었을 때는 `discardPile` 전체를 재사용하지 않고,  
현재 공개 상태를 대표하는 `lastCard`만 남기고 나머지만 `GameSetupService.shuffle()`로 섞어 새 드로우 덱을 구성합니다.

즉, 게임 상태를 표현하는 카드와 재활용 가능한 카드 풀을 분리해 처리했습니다.

### 4. 실시간 UX를 위한 시스템 로그 추가
재셔플이 발생하는 경우 클라이언트가 맥락을 이해할 수 있도록  
`"드로우할 카드가 없어 버린 패를 다시 섞습니다."` 시스템 로그를 남기도록 했습니다.

## 🧪 테스트
<img width="345" height="17" alt="image" src="https://github.com/user-attachments/assets/f037f0ac-32c3-4b44-bf74-e0ca9e77d30b" />
<img width="538" height="111" alt="image" src="https://github.com/user-attachments/assets/a66debe0-aae6-4ead-80a7-902b2de0b4c9" />

- `GameService`
  - 정상 드로우 시 hand/cardCount/turnOwner/lastActionId/log 검증
  - `roomId` mismatch 예외 검증
  - `drawPile` 소진 시 `discardPile` reshuffle 후 드로우 검증
- `GameGateway`
  - `DRAW_CARD` 핸들러 호출 검증
  - 서비스 예외 전파 검증
  - `roomId` 전달 검증
  - Guard / Interceptor / SubscribeMessage 메타데이터 검증

## 🎯 기대 효과
- 드로우 액션을 플레이 액션과 같은 수준의 서버 상태 변경 단위로 다룰 수 있음
- 덱 소진 상황에서도 게임이 자연스럽게 이어짐
- 클라이언트가 드로우 및 재셔플 상황을 실시간으로 해석하기 쉬워짐