### PR TITLE
feat: [ANI-20] 턴 매니저 고도화

### DIFF
--- a/src/modules/game/game.service.spec.ts
+++ b/src/modules/game/game.service.spec.ts
@@ -9,12 +9,15 @@ import { LogType } from "src/shared/enums/log.enum";
 import { createMock } from '@golevelup/ts-jest';
 import { ActionValidatorRegistry } from "./validators/action-validator.registry";
 import { ActionValidator } from "./validators/action-validator.interface";
+import { TurnManagerService } from "./turn-manager.service";
+import { TurnEffect } from "./turn-manager.interface";
 
 describe('GameService (Unit)', () => {
   let service: GameService;
   let gameSetupService: jest.Mocked<GameSetupService>;
   let roomService: jest.Mocked<RoomService>;
   let actionValidatorRegistry: jest.Mocked<ActionValidatorRegistry>;
+  let turnManager: jest.Mocked<TurnManagerService>;
 
   let host: ReturnType<typeof mockUser>;
   let room: GameRoom;
@@ -23,11 +26,13 @@ describe('GameService (Unit)', () => {
     gameSetupService = createMock<GameSetupService>();
     roomService = createMock<RoomService>();
     actionValidatorRegistry = createMock<ActionValidatorRegistry>();
+    turnManager = createMock<TurnManagerService>();
 
     service = new GameService(
       gameSetupService,
       roomService,
       actionValidatorRegistry,
+      turnManager,
     );
 
     host = mockUser();
@@ -60,6 +65,32 @@ describe('GameService (Unit)', () => {
         remainingDeck: deck.slice(players.length * count),
       };
     });
+
+    turnManager.pickFirstTurnOwner.mockImplementation(
+      (targetRoom) =>
+        targetRoom.players.find(
+          (player) => player.role === 'PLAYER',
+        )!.userId,
+    );
+    turnManager.applyTurnEffect.mockImplementation(
+      ({ room: targetRoom }) => {
+        targetRoom.isBonusTurn = false;
+        targetRoom.turnOwner =
+          targetRoom.players.find(
+            (player) => player.role === 'PLAYER',
+          )!.userId;
+        return targetRoom.turnOwner;
+      },
+    );
+    turnManager.resolveTurnAfterDraw.mockImplementation(
+      ({ room: targetRoom }) => {
+        targetRoom.turnOwner =
+          targetRoom.players.find(
+            (player) => player.role === 'PLAYER',
+          )!.userId;
+        return targetRoom.turnOwner;
+      },
+    );
   });
 
   describe('startGame', () => {
@@ -275,30 +306,19 @@ describe('GameService (Unit)', () => {
       });
       room.players[0].hand = [hostCard];
       room.players[0].cardCount = 1;
+      room.players[1].hand = [];
+      room.players[1].cardCount = 0;
 
       validator = {
         supports: jest.fn().mockReturnValue(true),
         validate: jest.fn(),
       };
 
-      roomService.getNextTurnOwner.mockImplementation(
-        (targetRoom, currentUserId) => {
-          const activePlayers = targetRoom.players.filter(
-            (p) => p.role === 'PLAYER' && !p.isOut,
-          );
-
-          if (activePlayers.length === 1) {
-            return activePlayers[0].userId;
-          }
-
-          const index = activePlayers.findIndex(
-            (p) => p.userId === currentUserId,
-          );
-          const nextIndex =
-            (index + targetRoom.direction + activePlayers.length) %
-            activePlayers.length;
-
-          return activePlayers[nextIndex].userId;
+      turnManager.applyTurnEffect.mockImplementation(
+        ({ room: targetRoom }) => {
+          targetRoom.turnOwner = guest.userId;
+          targetRoom.isBonusTurn = false;
+          return guest.userId;
         },
       );
 
@@ -307,7 +327,7 @@ describe('GameService (Unit)', () => {
       );
     });
 
-    it('정상 카드 제출 시 registry를 호출해야 한다', () => {
+    it('정상 카드 제출 시 registry를 호출하고, TurnManager를 호출해야 한다', () => {
       service.playCard(host.userId, hostCard.id);
 
       expect(
@@ -324,6 +344,15 @@ describe('GameService (Unit)', () => {
           card: hostCard,
         }),
       );
+      expect(
+        turnManager.applyTurnEffect,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          room,
+          playerId: host.userId,
+          effect: expect.any(Object),
+        }),
+      );
     });
 
     it('validator 미존재/중복 예외를 그대로 전파해야 한다', () => {
@@ -334,6 +363,24 @@ describe('GameService (Unit)', () => {
       expect(() =>
         service.playCard(host.userId, hostCard.id),
       ).toThrow(WsException);
+    });
+
+    it('validator 단계에서 실패하면 TurnManager를 호출하지 않고 상태를 변경하지 않아야 한다', () => {
+      validator.validate = jest.fn(() => {
+        throw new WsException('Invalid move');
+      });
+
+      expect(() =>
+        service.playCard(host.userId, hostCard.id),
+      ).toThrow(WsException);
+
+      expect(
+        turnManager.applyTurnEffect,
+      ).not.toHaveBeenCalled();
+      expect(room.players[0].hand).toEqual([hostCard]);
+      expect(room.players[0].cardCount).toBe(1);
+      expect(room.lastCard?.id).not.toBe(hostCard.id);
+      expect(room.lastActionId).toBe(0);
     });
 
     it('검증 통과 후 hand/discard/turn/lastActionId를 반영하고 로깅해야 한다', () => {
@@ -355,6 +402,41 @@ describe('GameService (Unit)', () => {
       expect(updatedRoom.lastActionId).toBe(1);
       expect(updatedRoom.turnOwner).toBe(guest.userId);
       expect(roomService.pushLog).toHaveBeenCalledTimes(1);
+    });
+
+    it('TurnManager는 discard와 공격 상태가 반영된 뒤 호출되어야 한다', () => {
+      const attackCard = createMockCard({
+        id: uuidv4(),
+        type: CardType.ATTACK,
+        value: 'SWORD_2',
+        power: 2,
+        suit: CardSuit.RABBIT,
+      });
+
+      setHostCardForPlay(attackCard);
+
+      service.playCard(host.userId, attackCard.id);
+
+      expect(
+        turnManager.applyTurnEffect,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          room: expect.objectContaining({
+            lastCard: expect.objectContaining({
+              id: attackCard.id,
+            }),
+            attackStack: 2,
+            currentPower: 2,
+          }),
+          playerId: host.userId,
+          effect: expect.objectContaining({
+            keepTurn: false,
+            advanceSteps: 1,
+            reverseDirection: false,
+            bonusTurn: false,
+          }),
+        }),
+      );
     });
 
     const setHostCardForPlay = (
@@ -445,6 +527,13 @@ describe('GameService (Unit)', () => {
       });
 
       setHostCardForPlay(bonusCard);
+      turnManager.applyTurnEffect.mockImplementation(
+        ({ room: targetRoom, playerId }) => {
+          targetRoom.turnOwner = playerId;
+          targetRoom.isBonusTurn = true;
+          return playerId;
+        },
+      );
 
       service.playCard(host.userId, bonusCard.id);
 
@@ -462,6 +551,15 @@ describe('GameService (Unit)', () => {
 
       const previousDirection = room.direction;
       setHostCardForPlay(reverseCard);
+      turnManager.applyTurnEffect.mockImplementation(
+        ({ room: targetRoom }) => {
+          targetRoom.direction =
+            previousDirection * -1;
+          targetRoom.turnOwner = guest.userId;
+          targetRoom.isBonusTurn = false;
+          return guest.userId;
+        },
+      );
 
       service.playCard(host.userId, reverseCard.id);
 
@@ -479,6 +577,13 @@ describe('GameService (Unit)', () => {
 
       room.direction = GameDirection.CLOCKWISE;
       setHostCardForPlay(skipCard);
+      turnManager.applyTurnEffect.mockImplementation(
+        ({ room: targetRoom, playerId }) => {
+          targetRoom.turnOwner = playerId;
+          targetRoom.isBonusTurn = false;
+          return playerId;
+        },
+      );
 
       service.playCard(host.userId, skipCard.id);
 
@@ -514,6 +619,18 @@ describe('GameService (Unit)', () => {
           chosenSuit: CardSuit.CAT,
         }),
       );
+      expect(
+        turnManager.applyTurnEffect,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          effect: expect.objectContaining({
+            keepTurn: false,
+            advanceSteps: 1,
+            reverseDirection: false,
+            bonusTurn: false,
+          }),
+        }),
+      );
     });
   });
 
@@ -540,27 +657,13 @@ describe('GameService (Unit)', () => {
       room.drawPile = [drawnCard];
       room.players[0].hand = [];
       room.players[0].cardCount = 0;
-
-      roomService.getNextTurnOwner.mockImplementation(
-        (targetRoom, currentUserId) => {
-          const activePlayers = targetRoom.players.filter(
-            (p) => p.role === 'PLAYER' && !p.isOut,
-          );
-
-          if (activePlayers.length === 1) {
-            return activePlayers[0].userId;
-          }
-
-          const index = activePlayers.findIndex(
-            (p) => p.userId === currentUserId,
-          );
-          const nextIndex =
-            (index + targetRoom.direction + activePlayers.length) %
-            activePlayers.length;
-
-          return activePlayers[nextIndex].userId;
+      turnManager.resolveTurnAfterDraw.mockImplementation(
+        ({ room: targetRoom }) => {
+          targetRoom.turnOwner = guest.userId;
+          return guest.userId;
         },
       );
+
     });
 
     it('drawPile의 맨 앞 카드를 호출한 플레이어 hand에 추가하고 턴/액션/로그를 갱신해야 한다', () => {
@@ -585,6 +688,23 @@ describe('GameService (Unit)', () => {
           actorId: host.userId,
           actorName: host.nickname,
           cardId: drawnCard.id,
+        }),
+      );
+    });
+
+    it('드로우 후 TurnManager는 hand/cardCount가 반영된 플레이어 상태를 받아야 한다', () => {
+      service.drawCard(host.userId, room.roomId);
+
+      expect(
+        turnManager.resolveTurnAfterDraw,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          room,
+          player: expect.objectContaining({
+            userId: host.userId,
+            hand: [drawnCard],
+            cardCount: 1,
+          }),
         }),
       );
     });
@@ -655,6 +775,31 @@ describe('GameService (Unit)', () => {
           cardId: recycledCardB.id,
         }),
       );
+    });
+
+    it('재사용 가능한 카드가 없으면 예외를 던지고 TurnManager를 호출하지 않아야 한다', () => {
+      const lastCard = createMockCard({
+        id: uuidv4(),
+        suit: CardSuit.BEAR,
+        value: '8',
+      });
+
+      room.lastCard = lastCard;
+      room.drawPile = [];
+      room.discardPile = [lastCard];
+
+      expect(() =>
+        service.drawCard(host.userId, room.roomId),
+      ).toThrow(
+        new WsException('No cards left in draw pile'),
+      );
+
+      expect(
+        turnManager.resolveTurnAfterDraw,
+      ).not.toHaveBeenCalled();
+      expect(room.players[0].hand).toEqual([]);
+      expect(room.players[0].cardCount).toBe(0);
+      expect(room.lastActionId).toBe(0);
     });
   });
 });

--- a/src/modules/game/game.service.ts
+++ b/src/modules/game/game.service.ts
@@ -8,6 +8,8 @@ import { Injectable } from "@nestjs/common";
 import { ActionValidatorRegistry } from "./validators/action-validator.registry";
 import { GameLog } from "src/shared/interfaces/log.interface";
 import { v4 as uuidv4 } from 'uuid';
+import { TurnManagerService } from "./turn-manager.service";
+import { TurnEffect } from "./turn-manager.interface";
 
 @Injectable()
 export class GameService {
@@ -15,6 +17,7 @@ export class GameService {
     private readonly gameSetupService: GameSetupService,
     private readonly roomService: RoomService,
     private readonly actionValidatorRegistry: ActionValidatorRegistry,
+    private readonly turnManager: TurnManagerService,
   ) { }
 
   startGame(userId: string): GameRoom {
@@ -119,12 +122,8 @@ export class GameService {
 
     room.status = 'PLAYING';
 
-    const activePlayers = room.players.filter(
-      p => p.role === 'PLAYER' && !p.isOut
-    );
-
-    const randomIndex = Math.floor(Math.random() * activePlayers.length);
-    room.turnOwner = activePlayers[randomIndex].userId;
+    room.turnOwner =
+      this.turnManager.pickFirstTurnOwner(room);
 
     room.direction = GameDirection.CLOCKWISE;
     room.attackStack = 0;
@@ -171,7 +170,15 @@ export class GameService {
     player.cardCount = player.hand.length;
 
     this.pushToDiscardPile(room, card);
-    this.applyCardEffect(room, player, card);
+    this.applyCardStateEffect(room, card);
+    this.turnManager.applyTurnEffect({
+      room,
+      playerId: player.userId,
+      effect: this.resolveTurnEffect(
+        room,
+        card,
+      ),
+    });
     this.pushPlayCardLog(room, player, card);
 
     room.lastActionId += 1;
@@ -199,10 +206,10 @@ export class GameService {
 
     player.hand.push(card);
     player.cardCount = player.hand.length;
-    room.turnOwner = this.roomService.getNextTurnOwner(
+    this.turnManager.resolveTurnAfterDraw({
       room,
-      player.userId,
-    );
+      player,
+    });
     room.lastActionId += 1;
     this.pushDrawCardLog(room, player, card);
 
@@ -276,70 +283,78 @@ export class GameService {
     return card;
   }
 
-  private applyCardEffect(
+  private applyCardStateEffect(
     room: GameRoom,
-    player: Player,
     card: Card,
   ): void {
-    let advanceSteps = 1;
-    let keepTurn = false;
-
     if (card.type === CardType.ATTACK) {
       room.attackStack += card.power;
       room.currentPower = card.power;
     } else if (card.type === CardType.NUMBER) {
       room.attackStack = 0;
       room.currentPower = 0;
-      room.isBonusTurn = false;
     } else if (card.type === CardType.SPECIAL) {
       switch (card.value) {
         case 'SHIELD':
           room.attackStack = 0;
           room.currentPower = 0;
-          room.isBonusTurn = false;
-          break;
-        case 'EVADE':
-          // intentinally no-op
-          break;
-        case 'BONUS':
-          keepTurn = true;
-          room.isBonusTurn = true;
-          break;
-        case 'REVERSE':
-          room.direction =
-            room.direction === GameDirection.CLOCKWISE
-              ? GameDirection.COUNTER_CLOCKWISE
-              : GameDirection.CLOCKWISE;
-          room.isBonusTurn = false;
-          break;
-        case 'JUMP':
-          advanceSteps = 2;
-          room.isBonusTurn = false;
           break;
         default:
-          room.isBonusTurn = false;
           break;
       }
-    } else if (card.type === CardType.WILD) {
-      // Wild는 suit 선언만 변경하고 턴/보너스 상태만 일반 진행으로 정리한다.
-      room.isBonusTurn = false;
-    } else {
-      room.isBonusTurn = false;
+    }
+  }
+
+  private resolveTurnEffect(
+    room: GameRoom,
+    card: Card,
+  ): TurnEffect {
+    if (card.type === CardType.SPECIAL) {
+      switch (card.value) {
+        case 'BONUS':
+          return {
+            keepTurn: true,
+            advanceSteps: 1,
+            reverseDirection: false,
+            bonusTurn: true,
+          };
+        case 'REVERSE':
+          return {
+            keepTurn: false,
+            advanceSteps: 1,
+            reverseDirection: true,
+            bonusTurn: false,
+          };
+        case 'JUMP':
+          return {
+            keepTurn: false,
+            advanceSteps: 2,
+            reverseDirection: false,
+            bonusTurn: false,
+          };
+        case 'EVADE':
+          return {
+            keepTurn: false,
+            advanceSteps: 1,
+            reverseDirection: false,
+            bonusTurn: room.isBonusTurn,
+          };
+        default:
+          return {
+            keepTurn: false,
+            advanceSteps: 1,
+            reverseDirection: false,
+            bonusTurn: false,
+          };
+      }
     }
 
-    if (keepTurn) {
-      room.turnOwner = player.userId;
-      return;
-    }
-
-    let nextTurnOwner = player.userId;
-    for (let i = 0; i < advanceSteps; i += 1) {
-      nextTurnOwner = this.roomService.getNextTurnOwner(
-        room,
-        nextTurnOwner,
-      );
-    }
-    room.turnOwner = nextTurnOwner;
+    return {
+      keepTurn: false,
+      advanceSteps: 1,
+      reverseDirection: false,
+      bonusTurn: false,
+    };
   }
 
   private pushPlayCardLog(

--- a/src/modules/game/turn-manager.interface.ts
+++ b/src/modules/game/turn-manager.interface.ts
@@ -1,0 +1,55 @@
+import { GameRoom, Player } from 'src/shared/interfaces/game.interface';
+
+export interface TurnEffect {
+  // 이번 액션 직후 턴을 넘기지 않고 현재 플레이어가 즉시 한 번 더 행동해야 하는지 나타낸다.
+  keepTurn: boolean;
+  // keepTurn 이 false 일 때 몇 칸 전진할지 나타낸다.
+  advanceSteps: number;
+  // true 면 다음 턴 계산 전에 진행 방향을 반전한다.
+  reverseDirection: boolean;
+  // 턴 유지 여부와 별개로, 액션 적용 후 room.isBonusTurn 에 저장할 상태다.
+  // 클라이언트 UI 와 후속 규칙 판정에서 "보너스 턴 상태가 남아있는가"를 표현한다.
+  bonusTurn: boolean;
+}
+
+export interface ApplyTurnEffectParams {
+  room: GameRoom;
+  playerId: string;
+  effect: TurnEffect;
+}
+
+export interface ResolveTurnAfterDrawParams {
+  room: GameRoom;
+  player: Player;
+}
+
+export interface ResolveTurnAfterLeaveParams {
+  room: GameRoom;
+  // leave 처리 직전 기준 현재 턴 주인이던 플레이어 ID
+  currentTurnOwnerId: string;
+  // 나가는 유저를 제외한 남은 플레이어 목록. 제거 전/후 호출 순서에 덜 민감한 계약을 위해 받는다.
+  remainingPlayers: Player[];
+}
+
+/**
+ * 턴 상태 전이만을 담당하는 도메인 계약.
+ * 카드 효과 전체가 아니라 "누가 다음 턴을 가지는가"와
+ * 그 계산에 필요한 방향/보너스 턴 메타데이터만 다룬다.
+ */
+export interface TurnManager {
+  pickFirstTurnOwner(room: GameRoom): string;
+  getNextActivePlayerId(
+    room: GameRoom,
+    currentUserId: string,
+    stepCount?: number,
+  ): string;
+  applyTurnEffect(
+    params: ApplyTurnEffectParams,
+  ): string;
+  resolveTurnAfterDraw(
+    params: ResolveTurnAfterDrawParams,
+  ): string;
+  resolveTurnAfterLeave(
+    params: ResolveTurnAfterLeaveParams,
+  ): string | null;
+}

--- a/src/modules/game/turn-manager.service.spec.ts
+++ b/src/modules/game/turn-manager.service.spec.ts
@@ -1,0 +1,437 @@
+import { WsException } from '@nestjs/websockets';
+
+import {
+  CardSuit,
+  CardType,
+  GameDirection,
+} from 'src/shared/enums/game.enum';
+import {
+  Card,
+  GameRoom,
+  Player,
+} from 'src/shared/interfaces/game.interface';
+
+import { TurnManagerService } from './turn-manager.service';
+
+describe('TurnManagerService', () => {
+  let service: TurnManagerService;
+
+  beforeEach(() => {
+    service = new TurnManagerService();
+  });
+
+  describe('pickFirstTurnOwner', () => {
+    it('활성 플레이어 중 한 명을 첫 턴 주인으로 반환해야 한다', () => {
+      const room = createMockRoom();
+
+      const randomSpy = jest
+        .spyOn(Math, 'random')
+        .mockReturnValue(0.8);
+
+      const turnOwner =
+        service.pickFirstTurnOwner(room);
+
+      expect(turnOwner).toBe('guest-2');
+
+      randomSpy.mockRestore();
+    });
+  });
+
+  describe('getNextActivePlayerId', () => {
+    it('방향에 따라 다음 활성 플레이어를 반환해야 한다', () => {
+      const room = createMockRoom({
+        direction:
+          GameDirection.COUNTER_CLOCKWISE,
+      });
+
+      const nextPlayerId =
+        service.getNextActivePlayerId(
+          room,
+          'host',
+        );
+
+      expect(nextPlayerId).toBe('guest-2');
+    });
+
+    it('stepCount 만큼 전진해야 한다', () => {
+      const room = createMockRoom();
+
+      const nextPlayerId =
+        service.getNextActivePlayerId(
+          room,
+          'host',
+          2,
+        );
+
+      expect(nextPlayerId).toBe('guest-2');
+    });
+
+    it('활성 플레이어가 없으면 예외가 발생해야 한다', () => {
+      const room = createMockRoom({
+        players: [
+          createPlayer('host', {
+            isOut: true,
+          }),
+        ],
+      });
+
+      expect(() =>
+        service.getNextActivePlayerId(
+          room,
+          'host',
+        ),
+      ).toThrow(
+        new WsException('No active players'),
+      );
+    });
+
+    it('탈락한 플레이어는 건너뛰고 다음 활성 플레이어를 반환해야 한다', () => {
+      const room = createMockRoom({
+        players: [
+          createPlayer('host'),
+          createPlayer('guest-1', {
+            isOut: true,
+          }),
+          createPlayer('guest-2'),
+          createPlayer('guest-3'),
+        ],
+      });
+
+      const nextPlayerId =
+        service.getNextActivePlayerId(
+          room,
+          'host',
+        );
+
+      expect(nextPlayerId).toBe('guest-2');
+    });
+  });
+
+  describe('resolveTurnAfterCard', () => {
+    it('BONUS effect 는 현재 플레이어의 즉시 추가 행동을 허용하고, room 에 bonusTurn 상태도 남겨야 한다', () => {
+      const room = createMockRoom();
+      const player = room.players[0];
+      const effect = {
+        keepTurn: true,
+        advanceSteps: 1,
+        reverseDirection: false,
+        bonusTurn: true,
+      };
+
+      const nextTurnOwner =
+        service.applyTurnEffect({
+          room,
+          playerId: player.userId,
+          effect,
+        });
+
+      expect(nextTurnOwner).toBe(player.userId);
+      expect(room.turnOwner).toBe(player.userId);
+      expect(room.isBonusTurn).toBe(true);
+    });
+
+    it('JUMP 카드는 두 칸 전진해야 한다', () => {
+      const room = createMockRoom();
+      const player = room.players[0];
+      const effect = {
+        keepTurn: false,
+        advanceSteps: 2,
+        reverseDirection: false,
+        bonusTurn: false,
+      };
+
+      const nextTurnOwner =
+        service.applyTurnEffect({
+          room,
+          playerId: player.userId,
+          effect,
+        });
+
+      expect(nextTurnOwner).toBe('guest-2');
+      expect(room.turnOwner).toBe('guest-2');
+      expect(room.isBonusTurn).toBe(false);
+    });
+
+    it('2인 플레이에서 JUMP 카드는 자기 자신에게 턴이 돌아와야 한다', () => {
+      const room = createMockRoom({
+        players: [
+          createPlayer('host'),
+          createPlayer('guest-1'),
+        ],
+      });
+      const player = room.players[0];
+      const effect = {
+        keepTurn: false,
+        advanceSteps: 2,
+        reverseDirection: false,
+        bonusTurn: false,
+      };
+
+      const nextTurnOwner =
+        service.applyTurnEffect({
+          room,
+          playerId: player.userId,
+          effect,
+        });
+
+      expect(nextTurnOwner).toBe('host');
+      expect(room.turnOwner).toBe('host');
+    });
+
+    it('4인 플레이에서 JUMP 카드는 두 명째 다음 플레이어에게 넘어가야 한다', () => {
+      const room = createMockRoom({
+        players: [
+          createPlayer('host'),
+          createPlayer('guest-1'),
+          createPlayer('guest-2'),
+          createPlayer('guest-3'),
+        ],
+      });
+      const player = room.players[0];
+      const effect = {
+        keepTurn: false,
+        advanceSteps: 2,
+        reverseDirection: false,
+        bonusTurn: false,
+      };
+
+      const nextTurnOwner =
+        service.applyTurnEffect({
+          room,
+          playerId: player.userId,
+          effect,
+        });
+
+      expect(nextTurnOwner).toBe('guest-2');
+      expect(room.turnOwner).toBe('guest-2');
+    });
+
+    it('REVERSE 카드는 방향을 반전한 뒤 다음 턴을 계산해야 한다', () => {
+      const room = createMockRoom();
+      const player = room.players[0];
+      const effect = {
+        keepTurn: false,
+        advanceSteps: 1,
+        reverseDirection: true,
+        bonusTurn: false,
+      };
+
+      const nextTurnOwner =
+        service.applyTurnEffect({
+          room,
+          playerId: player.userId,
+          effect,
+        });
+
+      expect(room.direction).toBe(
+        GameDirection.COUNTER_CLOCKWISE,
+      );
+      expect(nextTurnOwner).toBe('guest-2');
+      expect(room.turnOwner).toBe('guest-2');
+    });
+
+    it('2인 플레이에서 REVERSE 카드는 상대 플레이어에게 턴이 넘어가야 한다', () => {
+      const room = createMockRoom({
+        players: [
+          createPlayer('host'),
+          createPlayer('guest-1'),
+        ],
+      });
+      const player = room.players[0];
+      const effect = {
+        keepTurn: false,
+        advanceSteps: 1,
+        reverseDirection: true,
+        bonusTurn: false,
+      };
+
+      const nextTurnOwner =
+        service.applyTurnEffect({
+          room,
+          playerId: player.userId,
+          effect,
+        });
+
+      expect(room.direction).toBe(
+        GameDirection.COUNTER_CLOCKWISE,
+      );
+      expect(nextTurnOwner).toBe('guest-1');
+      expect(room.turnOwner).toBe('guest-1');
+    });
+
+    it('4인 플레이에서 REVERSE 카드는 반대 방향의 직전 플레이어에게 턴이 넘어가야 한다', () => {
+      const room = createMockRoom({
+        players: [
+          createPlayer('host'),
+          createPlayer('guest-1'),
+          createPlayer('guest-2'),
+          createPlayer('guest-3'),
+        ],
+      });
+      const player = room.players[0];
+      const effect = {
+        keepTurn: false,
+        advanceSteps: 1,
+        reverseDirection: true,
+        bonusTurn: false,
+      };
+
+      const nextTurnOwner =
+        service.applyTurnEffect({
+          room,
+          playerId: player.userId,
+          effect,
+        });
+
+      expect(room.direction).toBe(
+        GameDirection.COUNTER_CLOCKWISE,
+      );
+      expect(nextTurnOwner).toBe('guest-3');
+      expect(room.turnOwner).toBe('guest-3');
+    });
+
+    it('일반 진행 effect 는 턴을 넘기면서 room 의 bonusTurn 상태를 해제해야 한다', () => {
+      const room = createMockRoom({
+        isBonusTurn: true,
+      });
+      const player = room.players[0];
+      const effect = {
+        keepTurn: false,
+        advanceSteps: 1,
+        reverseDirection: false,
+        bonusTurn: false,
+      };
+
+      service.applyTurnEffect({
+        room,
+        playerId: player.userId,
+        effect,
+      });
+
+      expect(room.isBonusTurn).toBe(false);
+      expect(room.turnOwner).toBe('guest-1');
+    });
+  });
+
+  describe('resolveTurnAfterDraw', () => {
+    it('드로우 후 다음 플레이어에게 턴을 넘겨야 한다', () => {
+      const room = createMockRoom();
+      const player = room.players[0];
+
+      const nextTurnOwner =
+        service.resolveTurnAfterDraw({
+          room,
+          player,
+        });
+
+      expect(nextTurnOwner).toBe('guest-1');
+      expect(room.turnOwner).toBe('guest-1');
+    });
+  });
+
+  describe('resolveTurnAfterLeave', () => {
+    it('현재 턴 플레이어가 나가면, 나가는 유저가 players 배열에 남아있는지와 무관하게 remainingPlayers 기준으로 다음 턴 주인을 계산해야 한다', () => {
+      const room = createMockRoom({
+        turnOwner: 'host',
+      });
+
+      const nextTurnOwner =
+        service.resolveTurnAfterLeave({
+          room,
+          currentTurnOwnerId: 'host',
+          remainingPlayers: room.players.filter(
+            (player) => player.userId !== 'host',
+          ),
+        });
+
+      expect(nextTurnOwner).toBe('guest-1');
+    });
+
+    it('현재 턴 플레이어가 아니면 null 을 반환해야 한다', () => {
+      const room = createMockRoom({
+        turnOwner: 'guest-1',
+      });
+
+      const nextTurnOwner =
+        service.resolveTurnAfterLeave({
+          room,
+          currentTurnOwnerId: 'host',
+          remainingPlayers: room.players.filter(
+            (player) => player.userId !== 'host',
+          ),
+        });
+
+      expect(nextTurnOwner).toBeNull();
+    });
+
+    it('현재 턴 플레이어가 나가고 다음 순번 플레이어가 탈락 상태면 그 다음 활성 플레이어에게 넘어가야 한다', () => {
+      const room = createMockRoom({
+        players: [
+          createPlayer('host'),
+          createPlayer('guest-1', {
+            isOut: true,
+          }),
+          createPlayer('guest-2'),
+        ],
+        turnOwner: 'host',
+      });
+
+      const nextTurnOwner =
+        service.resolveTurnAfterLeave({
+          room,
+          currentTurnOwnerId: 'host',
+          remainingPlayers: room.players.filter(
+            (player) => player.userId !== 'host',
+          ),
+        });
+
+      expect(nextTurnOwner).toBe('guest-2');
+    });
+  });
+});
+
+function createMockRoom(
+  overrides: Partial<GameRoom> = {},
+): GameRoom {
+  const players =
+    overrides.players ?? [
+      createPlayer('host'),
+      createPlayer('guest-1'),
+      createPlayer('guest-2'),
+    ];
+
+  return {
+    roomId: 'room-1',
+    hostId: 'host',
+    attackStack: 0,
+    currentPower: 0,
+    lastCard: null,
+    drawPile: [],
+    discardPile: [],
+    lastActionId: 0,
+    turnOwner: 'host',
+    isBonusTurn: false,
+    direction: GameDirection.CLOCKWISE,
+    players,
+    status: 'PLAYING',
+    recentLogs: [],
+    ...overrides,
+  };
+}
+
+function createPlayer(
+  userId: string,
+  overrides: Partial<Player> = {},
+): Player {
+  return {
+    userId,
+    nickname: userId,
+    isGuest: false,
+    hand: [],
+    cardCount: 0,
+    isReady: true,
+    isOut: false,
+    role: 'PLAYER',
+    ...overrides,
+  };
+}

--- a/src/modules/game/turn-manager.service.ts
+++ b/src/modules/game/turn-manager.service.ts
@@ -123,7 +123,7 @@ export class TurnManagerService implements TurnManager {
     }
 
     const nextRemainingPlayer =
-      this.findNextRemainingPlayer(
+      this.findNextRemainingPlayerInTurnOrder(
         room,
         currentTurnOwnerId,
         activeRemainingPlayers,
@@ -139,7 +139,7 @@ export class TurnManagerService implements TurnManager {
     );
   }
 
-  private findNextRemainingPlayer(
+  private findNextRemainingPlayerInTurnOrder(
     room: GameRoom,
     currentTurnOwnerId: string,
     remainingPlayers: Player[],

--- a/src/modules/game/turn-manager.service.ts
+++ b/src/modules/game/turn-manager.service.ts
@@ -1,0 +1,237 @@
+import { Injectable } from '@nestjs/common';
+import { WsException } from '@nestjs/websockets';
+
+import {
+  GameDirection,
+} from 'src/shared/enums/game.enum';
+import {
+  GameRoom,
+  Player,
+} from 'src/shared/interfaces/game.interface';
+
+import {
+  ApplyTurnEffectParams,
+  ResolveTurnAfterDrawParams,
+  ResolveTurnAfterLeaveParams,
+  TurnManager,
+} from './turn-manager.interface';
+
+@Injectable()
+export class TurnManagerService implements TurnManager {
+  pickFirstTurnOwner(room: GameRoom): string {
+    const activePlayers =
+      this.getActivePlayers(room);
+    const randomIndex = Math.floor(
+      Math.random() * activePlayers.length,
+    );
+
+    return activePlayers[randomIndex].userId;
+  }
+
+  getNextActivePlayerId(
+    room: GameRoom,
+    currentUserId: string,
+    stepCount = 1,
+  ): string {
+    if (stepCount < 1) {
+      throw new WsException(
+        'stepCount must be greater than 0',
+      );
+    }
+
+    let nextUserId = currentUserId;
+    for (let i = 0; i < stepCount; i += 1) {
+      nextUserId = this.getImmediateNextActivePlayerId(
+        room,
+        nextUserId,
+      );
+    }
+
+    return nextUserId;
+  }
+
+  applyTurnEffect({
+    room,
+    playerId,
+    effect,
+  }: ApplyTurnEffectParams): string {
+    if (effect.reverseDirection) {
+      room.direction =
+        room.direction ===
+        GameDirection.CLOCKWISE
+          ? GameDirection.COUNTER_CLOCKWISE
+          : GameDirection.CLOCKWISE;
+    }
+
+    room.isBonusTurn = effect.bonusTurn;
+
+    if (effect.keepTurn) {
+      room.turnOwner = playerId;
+      return playerId;
+    }
+
+    const nextTurnOwner =
+      this.getNextActivePlayerId(
+        room,
+        playerId,
+        effect.advanceSteps,
+      );
+    room.turnOwner = nextTurnOwner;
+
+    return nextTurnOwner;
+  }
+
+  resolveTurnAfterDraw({
+    room,
+    player,
+  }: ResolveTurnAfterDrawParams): string {
+    const nextTurnOwner =
+      this.getNextActivePlayerId(
+        room,
+        player.userId,
+      );
+    room.turnOwner = nextTurnOwner;
+
+    return nextTurnOwner;
+  }
+
+  resolveTurnAfterLeave({
+    room,
+    currentTurnOwnerId,
+    remainingPlayers,
+  }: ResolveTurnAfterLeaveParams): string | null {
+    if (
+      room.status !== 'PLAYING' ||
+      room.turnOwner !== currentTurnOwnerId
+    ) {
+      return null;
+    }
+
+    const activeRemainingPlayers =
+      remainingPlayers.filter(
+        (player) =>
+          player.role === 'PLAYER' &&
+          !player.isOut,
+      );
+
+    if (activeRemainingPlayers.length === 0) {
+      return null;
+    }
+
+    if (activeRemainingPlayers.length === 1) {
+      return activeRemainingPlayers[0].userId;
+    }
+
+    const nextRemainingPlayer =
+      this.findNextRemainingPlayer(
+        room,
+        currentTurnOwnerId,
+        activeRemainingPlayers,
+      );
+
+    if (nextRemainingPlayer) {
+      return nextRemainingPlayer.userId;
+    }
+
+    return this.getNextActivePlayerId(
+      room,
+      currentTurnOwnerId,
+    );
+  }
+
+  private findNextRemainingPlayer(
+    room: GameRoom,
+    currentTurnOwnerId: string,
+    remainingPlayers: Player[],
+  ): Player | null {
+    const remainingPlayerIds =
+      new Set(
+        remainingPlayers.map(
+          (player) => player.userId,
+        ),
+      );
+    const currentIndex = room.players.findIndex(
+      (player) =>
+        player.userId === currentTurnOwnerId,
+    );
+
+    if (currentIndex === -1) {
+      throw new WsException(
+        'Current turn owner not found in room order',
+      );
+    }
+
+    const orderedPlayers = room.players;
+    const totalPlayers = orderedPlayers.length;
+
+    for (let step = 1; step <= totalPlayers; step += 1) {
+      const nextIndex =
+        (currentIndex +
+          room.direction * step +
+          totalPlayers) %
+        totalPlayers;
+      const candidate =
+        orderedPlayers[nextIndex];
+
+      if (
+        candidate &&
+        remainingPlayerIds.has(
+          candidate.userId,
+        )
+      ) {
+        return candidate;
+      }
+    }
+
+    return null;
+  }
+
+  private getImmediateNextActivePlayerId(
+    room: GameRoom,
+    currentUserId: string,
+  ): string {
+    const activePlayers =
+      this.getActivePlayers(room);
+
+    if (activePlayers.length === 1) {
+      return activePlayers[0].userId;
+    }
+
+    const index = activePlayers.findIndex(
+      (player) =>
+        player.userId === currentUserId,
+    );
+
+    if (index === -1) {
+      throw new WsException(
+        'Invalid user',
+      );
+    }
+
+    const nextIndex =
+      (index +
+        room.direction +
+        activePlayers.length) %
+      activePlayers.length;
+
+    return activePlayers[nextIndex].userId;
+  }
+
+  private getActivePlayers(
+    room: GameRoom,
+  ): Player[] {
+    const activePlayers = room.players.filter(
+      (player) =>
+        player.role === 'PLAYER' &&
+        !player.isOut,
+    );
+
+    if (activePlayers.length === 0) {
+      throw new WsException(
+        'No active players',
+      );
+    }
+
+    return activePlayers;
+  }
+}

--- a/src/modules/socket/game.gateway.spec.ts
+++ b/src/modules/socket/game.gateway.spec.ts
@@ -16,6 +16,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { GameParticipantGuard } from 'src/common/guards/game-participant.guard';
 import { TurnOwnerGuard } from 'src/common/guards/turnowner.guard';
 import { GameResponseInterceptor } from './interceptors/game-response.interceptor';
+import { TurnManagerService } from '../game/turn-manager.service';
 
 describe('GameGateway', () => {
   let gateway: GameGateway;
@@ -277,11 +278,13 @@ describe('GameGateway disconnect cleanup', () => {
   let authService: jest.Mocked<AuthService>;
   let gameService: jest.Mocked<GameService>;
   let roomService: RoomService;
+  let turnManager: jest.Mocked<TurnManagerService>;
 
   beforeEach(() => {
     authService = createMock<AuthService>();
     gameService = createMock<GameService>();
-    roomService = new RoomService();
+    turnManager = createMock<TurnManagerService>();
+    roomService = new RoomService(turnManager);
 
     gateway = new GameGateway(
       authService,
@@ -337,6 +340,10 @@ describe('GameGateway disconnect cleanup', () => {
     const guest2 = mockUser();
     const room = roomService.createRoom(host);
 
+    turnManager.resolveTurnAfterLeave.mockReturnValue(
+      guest1.userId,
+    );
+
     roomService.joinRoom(room.roomId, guest1);
     roomService.joinRoom(room.roomId, guest2);
 
@@ -344,12 +351,10 @@ describe('GameGateway disconnect cleanup', () => {
     room.direction = GameDirection.CLOCKWISE;
     room.turnOwner = host.userId;
 
-    const expectedNextTurnOwner = roomService.getNextTurnOwner(room, host.userId);
-
     gateway.handleDisconnect(createClient(host));
 
     const updatedRoom = roomService.getRoom(room.roomId);
-    expect(updatedRoom?.turnOwner).toBe(expectedNextTurnOwner);
+    expect(updatedRoom?.turnOwner).toBe(guest1.userId);
   });
 
   it('마지막 유저 disconnect 시 방이 삭제되어야 한다', () => {

--- a/src/modules/socket/game.module.ts
+++ b/src/modules/socket/game.module.ts
@@ -16,6 +16,7 @@ import { ShieldCardValidator } from "../game/validators/shield-card-action.valid
 import { EvadeCardValidator } from "../game/validators/evade-card-action.validator";
 import { BonusCardValidator } from "../game/validators/bonus-card-action.validator";
 import { WildcardActionValidator } from "../game/validators/wildcard-action.validator";
+import { TurnManagerService } from "../game/turn-manager.service";
 
 @Module({
   imports: [AuthModule],
@@ -35,6 +36,7 @@ import { WildcardActionValidator } from "../game/validators/wildcard-action.vali
     EvadeCardValidator,
     BonusCardValidator,
     WildcardActionValidator,
+    TurnManagerService,
     {
       provide: ACTION_VALIDATORS,
       useFactory: (

--- a/src/modules/socket/room.service.spec.ts
+++ b/src/modules/socket/room.service.spec.ts
@@ -206,12 +206,10 @@ describe('RoomService', () => {
       room.turnOwner = host.userId;
       room.direction = GameDirection.CLOCKWISE;
 
-      const expectedNext = service.getNextTurnOwner(room, room.turnOwner);
-
       service.leaveRoom(host.userId);
 
       const updatedRoom = service.getRoom(room.roomId);
-      expect(updatedRoom!.turnOwner).toBe(expectedNext);
+      expect(updatedRoom!.turnOwner).toBe(guest1.userId);
       expect(updatedRoom!.players.some(p => p.userId === updatedRoom!.turnOwner)).toBe(true); // 턴이 넘어간 유저가 실제 플레이어여야 한다
     });
 
@@ -229,15 +227,10 @@ describe('RoomService', () => {
       room.direction = GameDirection.COUNTER_CLOCKWISE;
       room.isBonusTurn = true;
 
-      const expectedNext = service.getNextTurnOwner(
-        room,
-        room.turnOwner,
-      );
-
       service.leaveRoom(guest2.userId);
 
       const updatedRoom = service.getRoom(room.roomId);
-      expect(updatedRoom!.turnOwner).toBe(expectedNext);
+      expect(updatedRoom!.turnOwner).toBe(guest1.userId);
       expect(updatedRoom!.direction).toBe(
         GameDirection.COUNTER_CLOCKWISE,
       );
@@ -249,50 +242,6 @@ describe('RoomService', () => {
 
       expect(result.isDeleted).toBe(true);
       expect(service.getRoom(room.roomId)).toBeUndefined();
-    });
-  });
-
-  describe('getNextTurnOwner', () => {
-    let room: GameRoom;
-
-    beforeEach(() => {
-      const host = mockUser();
-      room = service.createRoom(host);
-
-      const guest1 = mockUser();
-      const guest2 = mockUser();
-
-      service.joinRoom(room.roomId, guest1);
-      service.joinRoom(room.roomId, guest2);
-    });
-
-    it('direction에 따라 올바른 다음 턴 유저를 반환해야 한다', () => {
-      room.direction = GameDirection.COUNTER_CLOCKWISE;
-
-      const current = room.players[0].userId;
-      const players = room.players.map(p => p.userId);
-
-      const next = service.getNextTurnOwner(room, current);
-
-      const currentIndex = players.indexOf(current);
-      const expectedIndex = (currentIndex + room.direction + players.length) % players.length;
-
-      expect(next).toBe(players[expectedIndex]);
-    });
-
-    it('존재하지 않는 유저를 기준으로 하면 에러가 발생해야 한다', () => {
-      expect(() => {
-        service.getNextTurnOwner(room, 'invalid-user');
-      }).toThrow();
-    });
-
-    it('플레이어가 1명뿐이면 자기 자신을 반환해야 한다', () => {
-      const soloRoom = service.createRoom(mockUser());
-
-      const current = soloRoom.players[0].userId;
-      const next = service.getNextTurnOwner(soloRoom, current);
-
-      expect(next).toBe(current);
     });
   });
 

--- a/src/modules/socket/room.service.spec.ts
+++ b/src/modules/socket/room.service.spec.ts
@@ -3,12 +3,15 @@ import { RoomService } from './room.service';
 import { GameDirection } from 'src/shared/enums/game.enum';
 import { WsException } from '@nestjs/websockets';
 import { v4 as uuidv4 } from 'uuid';
+import { TurnManagerService } from 'src/modules/game/turn-manager.service';
 
 describe('RoomService', () => {
   let service: RoomService;
 
   beforeEach(() => {
-    service = new RoomService();
+    service = new RoomService(
+      new TurnManagerService(),
+    );
   });
 
   it('여러 방은 서로 영향을 주지 않아야 한다', () => {
@@ -210,6 +213,35 @@ describe('RoomService', () => {
       const updatedRoom = service.getRoom(room.roomId);
       expect(updatedRoom!.turnOwner).toBe(expectedNext);
       expect(updatedRoom!.players.some(p => p.userId === updatedRoom!.turnOwner)).toBe(true); // 턴이 넘어간 유저가 실제 플레이어여야 한다
+    });
+
+    it('REVERSE로 방향이 바뀌고 BONUS 상태가 남아있는 상황에서 현재 턴 유저가 나가면, 반대 방향 기준으로 턴이 넘어가고 기존 턴 메타 상태는 유지되어야 한다', () => {
+      const guest1 = mockUser();
+      const guest2 = mockUser();
+      const guest3 = mockUser();
+
+      service.joinRoom(room.roomId, guest1);
+      service.joinRoom(room.roomId, guest2);
+      service.joinRoom(room.roomId, guest3);
+
+      room.status = 'PLAYING';
+      room.turnOwner = guest2.userId;
+      room.direction = GameDirection.COUNTER_CLOCKWISE;
+      room.isBonusTurn = true;
+
+      const expectedNext = service.getNextTurnOwner(
+        room,
+        room.turnOwner,
+      );
+
+      service.leaveRoom(guest2.userId);
+
+      const updatedRoom = service.getRoom(room.roomId);
+      expect(updatedRoom!.turnOwner).toBe(expectedNext);
+      expect(updatedRoom!.direction).toBe(
+        GameDirection.COUNTER_CLOCKWISE,
+      );
+      expect(updatedRoom!.isBonusTurn).toBe(true);
     });
 
     it('방에 아무도 없으면 방이 삭제되어야 한다', () => {

--- a/src/modules/socket/room.service.ts
+++ b/src/modules/socket/room.service.ts
@@ -174,12 +174,6 @@ export class RoomService {
     return { room: room, roomId: roomId, isDeleted: false };
   }
 
-  getNextTurnOwner(room: GameRoom, currentUserId: string): string {
-    return this.turnManager.getNextActivePlayerId(
-      room,
-      currentUserId,
-    );
-  }
 
   toggleReady(userId: string): GameRoom {
     const roomId = this.userToRoom.get(userId);

--- a/src/modules/socket/room.service.ts
+++ b/src/modules/socket/room.service.ts
@@ -3,10 +3,12 @@ import { CardType, GameDirection } from 'src/shared/enums/game.enum';
 import { WsException } from '@nestjs/websockets';
 import { v4 as uuidv4 } from 'uuid';
 import { SocketData } from 'socket.io';
-import { Logger } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { LogType } from 'src/shared/enums/log.enum';
 import { GameLog } from 'src/shared/interfaces/log.interface';
+import { TurnManagerService } from 'src/modules/game/turn-manager.service';
 
+@Injectable()
 export class RoomService {
   // Key: roomId, Value: GameRoom
   private readonly rooms = new Map<string, GameRoom>();
@@ -16,6 +18,10 @@ export class RoomService {
   private readonly MAX_CAPACITY = 4; // players + spectators 포함
 
   private readonly logger = new Logger(RoomService.name);
+
+  constructor(
+    private readonly turnManager: TurnManagerService,
+  ) {}
 
   // roomId로 방 정보 조회
   getRoom(roomId: string): GameRoom | undefined {
@@ -125,11 +131,20 @@ export class RoomService {
     }
 
     const isTurnOwner = room.turnOwner === userId;
+    const remainingPlayers = room.players.filter(
+      (player) => player.userId !== userId,
+    );
 
     let nextTurnOwner: string | null = null;
 
-    if (room.status === 'PLAYING' && isTurnOwner)
-      nextTurnOwner = this.getNextTurnOwner(room, userId);
+    if (room.status === 'PLAYING' && isTurnOwner) {
+      nextTurnOwner =
+        this.turnManager.resolveTurnAfterLeave({
+          room,
+          currentTurnOwnerId: userId,
+          remainingPlayers,
+        });
+    }
 
     // 유저 제거
     room.players.splice(leavingIndex, 1);
@@ -160,27 +175,10 @@ export class RoomService {
   }
 
   getNextTurnOwner(room: GameRoom, currentUserId: string): string {
-    const activePlayers = room.players.filter(
-      p => p.role === 'PLAYER' && !p.isOut
+    return this.turnManager.getNextActivePlayerId(
+      room,
+      currentUserId,
     );
-
-    if (activePlayers.length === 0) {
-      throw new WsException('No active players');
-    }
-
-    if (activePlayers.length === 1) {
-      return activePlayers[0].userId;
-    }
-
-    const index = activePlayers.findIndex(p => p.userId === currentUserId);
-    if (index === -1) {
-      throw new WsException('Invalid user');
-    }
-
-    const nextIndex =
-      (index + room.direction + activePlayers.length) % activePlayers.length;
-
-    return activePlayers[nextIndex].userId;
   }
 
   toggleReady(userId: string): GameRoom {


### PR DESCRIPTION
## **🎯 개요**  
이번 PR은 턴 전이 책임을 `TurnManager`로 모으고, 카드 효과 해석과 실제 턴 상태 적용을 분리해 턴 규칙을 더 명확하게 관리할 수 있도록 정리한 변경입니다.  
기존에는 `GameService`와 `RoomService`가 각각 턴 주인 계산, 방향 반전, 보너스 턴 유지, 퇴장 시 턴 위임 등을 직접 처리하고 있었는데, 이번 변경으로 턴 관련 상태 전이를 하나의 도메인 계층에서 다루도록 구조를 정리했습니다.

## **🛠 주요 작업 내용**  
- `TurnManagerService` 및 관련 인터페이스 추가
- 게임 시작 시 첫 턴 선정 로직을 `TurnManager`로 위임
- 카드 사용 후 턴 유지/전진/역방향 전환/보너스 턴 상태 반영을 `TurnEffect` 기반으로 적용
- `drawCard()` 이후 다음 턴 계산을 `TurnManager`로 위임
- `leaveRoom()`에서 현재 턴 플레이어 이탈 시 턴 위임을 `TurnManager`로 위임
- `RoomService.getNextTurnOwner()`는 호환용 엔트리로 남기고 내부 구현만 `TurnManager`로 위임
- `GameService` 테스트에서 턴 계산 구현을 재현하지 않도록 mock 구성을 더 얇게 정리
- `TurnManagerService` 중심 시나리오 테스트 대폭 보강

## **🏗 핵심 설계 포인트**  
- **턴 전이 책임 단일화**  
  턴 주인 계산, 진행 방향 반전, 보너스 턴 상태 적용, 퇴장 시 턴 위임을 `TurnManager`로 집중시켜 규칙 변경 지점을 단일화했습니다.

- **카드 해석과 턴 적용 분리**  
  `GameService`는 카드가 턴에 미치는 영향을 `TurnEffect`로 해석하고, `TurnManager`는 그 결과를 실제 `turnOwner`, `direction`, `isBonusTurn`에 반영합니다.  
  이를 통해 `TurnManager`가 카드 종류 자체를 직접 해석하지 않도록 정리했습니다.

- **즉시 동작과 상태 플래그 분리**  
  `TurnEffect.keepTurn`은 “이번 액션 직후 즉시 추가 행동 여부”, `TurnEffect.bonusTurn`은 “액션 적용 후 room 상태에 남길 보너스 턴 플래그”로 분리했습니다.  
  이 구조는 서버의 턴 전이 규칙과 클라이언트 UI 상태 표현을 함께 수용하기 위한 설계입니다.

- **퇴장 시나리오 계약 개선**  
  `resolveTurnAfterLeave()`는 `leavingUserId` 중심에서 `currentTurnOwnerId + remainingPlayers` 기반으로 바뀌었습니다.  
  제거 전/후 호출 순서에 덜 민감하도록 계약을 바꿨고, 내부적으로는 `findNextRemainingPlayer(...)` helper를 두어 좌석 순서 기반 다음 플레이어 탐색 의도를 분리했습니다.

## **🧪 테스트 보강 내용**  
- `GameService`
  - validator 실패 시 `TurnManager` 미호출 및 상태 불변 검증
  - 카드 상태 반영 후 `TurnManager`가 호출되는지 검증
  - 드로우 후 hand/cardCount 갱신 상태로 `TurnManager`가 호출되는지 검증
  - 재사용 가능한 카드가 없을 때 예외 및 부수효과 없음 검증

- `TurnManagerService`
  - `BONUS`, `JUMP`, `REVERSE`의 턴 전이 시나리오
  - 2인/3인/4인 기준 `JUMP`/`REVERSE` 차이
  - 탈락 플레이어 스킵
  - 현재 턴 플레이어 이탈 시 다음 턴 계산
  - `remainingPlayers` 기반 leave 계약 검증

- `RoomService`
  - 현재 턴 유저 이탈 시 턴 위임
  - `REVERSE + BONUS` 상태가 남아있는 상황에서의 이탈 처리 검증

## **📌 기대 효과**  
- 턴 규칙 수정 시 변경 범위 축소
- 카드 효과와 턴 전이의 경계가 명확해져 유지보수성 향상
- 이탈/역방향/보너스 턴/탈락 스킵 같은 경계 시나리오 안정성 강화
- 향후 타임아웃, 재접속 복구, 자동 턴 스킵 같은 후속 작업을 붙이기 쉬운 구조 확보

## **📝 비고**  
- 이번 PR은 턴 전이 구조 정비에 초점을 맞췄습니다.
- 동시성 제어(`lastActionId` 기반 stale action 방어), 타임아웃 자동 처리, 종료 조건 처리 등은 별도 티켓에서 다룰 범위로 남겨두었습니다.