### PR TITLE
feat: [ANI-23] 동시성 제어 및 액션 시퀀싱(Action Sequencing) 시스템 구축

### DIFF
--- a/src/common/filters/ws-exception.filter.ts
+++ b/src/common/filters/ws-exception.filter.ts
@@ -1,6 +1,7 @@
 import { Catch, ArgumentsHost, Logger } from '@nestjs/common';
 import { BaseWsExceptionFilter, WsException } from '@nestjs/websockets';
 import { SocketEvent } from 'src/shared/enums/socket-event.enum';
+import { GameErrorCode } from 'src/shared/enums/game-error-code.enum';
 
 // WebSocket 전용 예외 필터
 @Catch(WsException)
@@ -11,17 +12,51 @@ export class WsExceptionFilter extends BaseWsExceptionFilter {
     const client = host.switchToWs().getClient();
     const data = host.switchToWs().getData();
     const error = exception instanceof WsException ? exception.getError() : exception.response;
+    const normalizedError = this.normalizeError(error);
 
     // 서버 터미널에 에러 로그 남기기
     this.logger.error(`Validation Failed for user ${client.data.user?.userId}`);
     this.logger.error(`Input Data: ${JSON.stringify(data)}`);
-    this.logger.error(`Error Detail: ${JSON.stringify(error)}`);
+    this.logger.error(`Error Detail: ${JSON.stringify(normalizedError)}`);
 
     // 클라이언트에게 에러 메시지 전송
     client.emit('response', {
       status: SocketEvent.GAME_ERROR,
+      message: normalizedError.message,
+      code: normalizedError.code,
+      details: normalizedError.details,
+    });
+  }
+
+  private normalizeError(error: unknown): {
+    message: string;
+    code?: GameErrorCode;
+    details: unknown;
+  } {
+    // TODO(ANI-29): WsException 에러코드 체계 도입 시
+    // { code, message } 형태의 모든 도메인 에러를 공통 포맷으로 일반화한다.
+    if (
+      this.isErrorPayload(error)
+      && error.code === GameErrorCode.GAME_STATE_OUTDATED
+    ) {
+      return {
+        message: error.message,
+        code: error.code,
+        details: error,
+      };
+    }
+
+    return {
       message: '잘못된 형식의 요청입니다.',
       details: error || 'Validation Error',
-    });
+    };
+  }
+
+  private isErrorPayload(
+    error: unknown,
+  ): error is { code?: GameErrorCode; message: string } {
+    return typeof error === 'object'
+      && error !== null
+      && 'message' in error;
   }
 }

--- a/src/modules/game/actions/game-action-executor.interface.ts
+++ b/src/modules/game/actions/game-action-executor.interface.ts
@@ -1,0 +1,5 @@
+import { GameAction } from 'src/shared/interfaces/game-action.interface';
+
+export interface GameActionExecutor {
+  execute(action: GameAction): Promise<void>;
+}

--- a/src/modules/game/actions/game-action-executor.service.spec.ts
+++ b/src/modules/game/actions/game-action-executor.service.spec.ts
@@ -1,0 +1,156 @@
+import { createMock } from '@golevelup/ts-jest';
+import { WsException } from '@nestjs/websockets';
+import { v4 as uuidv4 } from 'uuid';
+
+import { GameActionExecutorService } from './game-action-executor.service';
+import { GameService } from '../game.service';
+import { RoomService } from 'src/modules/socket/room.service';
+import { GameActionType } from 'src/shared/enums/game-action-type.enum';
+import { GameErrorCode } from 'src/shared/enums/game-error-code.enum';
+import { CardSuit, CardType, GameDirection } from 'src/shared/enums/game.enum';
+import { Card, GameRoom, Player } from 'src/shared/interfaces/game.interface';
+
+describe('GameActionExecutorService', () => {
+  let executor: GameActionExecutorService;
+  let roomService: jest.Mocked<RoomService>;
+  let gameService: jest.Mocked<GameService>;
+  let room: GameRoom;
+  let host: Player;
+  let guest: Player;
+
+  beforeEach(() => {
+    roomService = createMock<RoomService>();
+    gameService = createMock<GameService>();
+
+    executor = new GameActionExecutorService(
+      roomService,
+      gameService,
+    );
+
+    host = createPlayer('host-1');
+    guest = createPlayer('guest-1');
+    room = createRoom(host, guest);
+
+    roomService.getRoom.mockReturnValue(room);
+    gameService.playCard.mockReturnValue(room);
+    gameService.drawCard.mockReturnValue(room);
+  });
+
+  it('PLAY_CARD 실행 전 expectedActionId를 검증하고 성공 시 lastActionId를 증가시켜야 한다', async () => {
+    await executor.execute({
+      type: GameActionType.PLAY_CARD,
+      roomId: room.roomId,
+      userId: host.userId,
+      expectedActionId: 3,
+      cardId: 'card-1',
+      chosenSuit: CardSuit.CAT,
+    });
+
+    expect(gameService.playCard).toHaveBeenCalledWith(
+      host.userId,
+      'card-1',
+      CardSuit.CAT,
+    );
+    expect(room.lastActionId).toBe(4);
+  });
+
+  it('DRAW_CARD도 턴을 다시 검증하고 성공 시 lastActionId를 증가시켜야 한다', async () => {
+    await executor.execute({
+      type: GameActionType.DRAW_CARD,
+      roomId: room.roomId,
+      userId: host.userId,
+      expectedActionId: 3,
+    });
+
+    expect(gameService.drawCard).toHaveBeenCalledWith(
+      host.userId,
+      room.roomId,
+    );
+    expect(room.lastActionId).toBe(4);
+  });
+
+  it('expectedActionId가 다르면 GAME_STATE_OUTDATED를 반환하고 서비스를 호출하지 않아야 한다', async () => {
+    const execution = executor.execute({
+      type: GameActionType.DRAW_CARD,
+      roomId: room.roomId,
+      userId: host.userId,
+      expectedActionId: 2,
+    });
+
+    try {
+      await execution;
+      fail('expected execution to reject');
+    } catch (error) {
+      expect(error).toBeInstanceOf(WsException);
+      expect((error as WsException).getError()).toEqual({
+        code: GameErrorCode.GAME_STATE_OUTDATED,
+        message: 'Game state is outdated',
+      });
+    }
+
+    expect(gameService.drawCard).not.toHaveBeenCalled();
+    expect(room.lastActionId).toBe(3);
+  });
+
+  it('Guard를 통과했더라도 실행 직전 턴이 바뀌었으면 실패해야 한다', async () => {
+    room.turnOwner = guest.userId;
+
+    await expect(
+      executor.execute({
+        type: GameActionType.PLAY_CARD,
+        roomId: room.roomId,
+        userId: host.userId,
+        expectedActionId: 3,
+        cardId: 'card-1',
+      }),
+    ).rejects.toThrow(new WsException('Not your turn'));
+
+    expect(gameService.playCard).not.toHaveBeenCalled();
+    expect(room.lastActionId).toBe(3);
+  });
+});
+
+function createRoom(host: Player, guest: Player): GameRoom {
+  return {
+    roomId: uuidv4(),
+    hostId: host.userId,
+    attackStack: 0,
+    currentPower: 0,
+    lastCard: createCard(),
+    drawPile: [],
+    discardPile: [],
+    lastActionId: 3,
+    turnOwner: host.userId,
+    isBonusTurn: false,
+    direction: GameDirection.CLOCKWISE,
+    players: [host, guest],
+    status: 'PLAYING',
+    recentLogs: [],
+  };
+}
+
+function createPlayer(userId: string): Player {
+  return {
+    userId,
+    nickname: userId,
+    isGuest: false,
+    hand: [],
+    cardCount: 0,
+    isReady: true,
+    isOut: false,
+    role: 'PLAYER',
+  };
+}
+
+function createCard(overrides?: Partial<Card>): Card {
+  return {
+    id: uuidv4(),
+    suit: CardSuit.RABBIT,
+    declaredSuit: CardSuit.RABBIT,
+    type: CardType.NUMBER,
+    value: '1',
+    power: 0,
+    assetKey: 'rabbit_1',
+    ...overrides,
+  };
+}

--- a/src/modules/game/actions/game-action-executor.service.ts
+++ b/src/modules/game/actions/game-action-executor.service.ts
@@ -1,0 +1,111 @@
+import { Injectable } from '@nestjs/common';
+import { WsException } from '@nestjs/websockets';
+
+import { GameService } from '../game.service';
+import { RoomService } from 'src/modules/socket/room.service';
+import { GameActionExecutor } from './game-action-executor.interface';
+import { GameActionType } from 'src/shared/enums/game-action-type.enum';
+import { GameErrorCode } from 'src/shared/enums/game-error-code.enum';
+import { GameAction } from 'src/shared/interfaces/game-action.interface';
+import { GameRoom, Player } from 'src/shared/interfaces/game.interface';
+
+@Injectable()
+export class GameActionExecutorService implements GameActionExecutor {
+  constructor(
+    private readonly roomService: RoomService,
+    private readonly gameService: GameService,
+  ) {}
+
+  async execute(action: GameAction): Promise<void> {
+    const room = this.getExecutableRoom(action);
+
+    this.validateExpectedActionId(room, action.expectedActionId);
+
+    const player = this.getExecutablePlayer(room, action.userId);
+    this.validateTurnOwner(room, player.userId);
+
+    switch (action.type) {
+      case GameActionType.PLAY_CARD:
+        this.gameService.playCard(
+          action.userId,
+          action.cardId,
+          action.chosenSuit,
+        );
+        break;
+      case GameActionType.DRAW_CARD:
+        this.gameService.drawCard(
+          action.userId,
+          action.roomId,
+        );
+        break;
+      default:
+        this.assertUnreachable(action);
+    }
+
+    room.lastActionId += 1;
+  }
+
+  private getExecutableRoom(action: GameAction): GameRoom {
+    const room = this.roomService.getRoom(action.roomId);
+
+    if (!room) {
+      throw new WsException('Room not found');
+    }
+
+    if (room.status !== 'PLAYING') {
+      throw new WsException('Game has not started');
+    }
+
+    return room;
+  }
+
+  private validateExpectedActionId(
+    room: GameRoom,
+    expectedActionId: number,
+  ): void {
+    if (room.lastActionId !== expectedActionId) {
+      throw new WsException({
+        code: GameErrorCode.GAME_STATE_OUTDATED,
+        message: 'Game state is outdated',
+      });
+    }
+  }
+
+  private getExecutablePlayer(
+    room: GameRoom,
+    userId: string,
+  ): Player {
+    const player = room.players.find(
+      (candidate) => candidate.userId === userId,
+    );
+
+    if (!player) {
+      throw new WsException('User is not a participant of this room');
+    }
+
+    if (player.role === 'SPECTATOR') {
+      throw new WsException('Spectator cannot play');
+    }
+
+    if (player.isOut) {
+      throw new WsException('Player is already out');
+    }
+
+    return player;
+  }
+
+  private validateTurnOwner(
+    room: GameRoom,
+    userId: string,
+  ): void {
+    if (room.turnOwner !== userId) {
+      throw new WsException('Not your turn');
+    }
+  }
+
+  private assertUnreachable(action: never): never {
+    throw new WsException(
+      `Unsupported action type: ${(action as GameAction).type}`,
+    );
+  }
+}

--- a/src/modules/game/actions/game-action-queue.interface.ts
+++ b/src/modules/game/actions/game-action-queue.interface.ts
@@ -1,0 +1,5 @@
+import { GameAction } from 'src/shared/interfaces/game-action.interface';
+
+export interface GameActionQueue {
+  enqueue(action: GameAction): Promise<void>;
+}

--- a/src/modules/game/actions/game-action.token.ts
+++ b/src/modules/game/actions/game-action.token.ts
@@ -1,0 +1,2 @@
+export const GAME_ACTION_QUEUE = Symbol('GAME_ACTION_QUEUE');
+export const GAME_ACTION_EXECUTOR = Symbol('GAME_ACTION_EXECUTOR');

--- a/src/modules/game/actions/in-memory-game-action-queue.service.spec.ts
+++ b/src/modules/game/actions/in-memory-game-action-queue.service.spec.ts
@@ -1,0 +1,142 @@
+import { InMemoryGameActionQueue } from './in-memory-game-action-queue.service';
+import { GameActionExecutor } from './game-action-executor.interface';
+import { GameActionType } from 'src/shared/enums/game-action-type.enum';
+import { GameAction } from 'src/shared/interfaces/game-action.interface';
+
+describe('InMemoryGameActionQueue', () => {
+  let queue: InMemoryGameActionQueue;
+  let executor: jest.Mocked<GameActionExecutor>;
+
+  beforeEach(() => {
+    executor = {
+      execute: jest.fn(),
+    };
+
+    queue = new InMemoryGameActionQueue(executor);
+  });
+
+  it('같은 room의 액션은 순차적으로 처리해야 한다', async () => {
+    const started: string[] = [];
+    const releaseByUserId = new Map<string, () => void>();
+
+    executor.execute.mockImplementation((action) => {
+      started.push(action.userId);
+
+      return new Promise<void>((resolve) => {
+        releaseByUserId.set(action.userId, resolve);
+      });
+    });
+
+    const firstAction = createDrawAction('room-1', 'user-1');
+    const secondAction = createDrawAction('room-1', 'user-2');
+
+    const firstPromise = queue.enqueue(firstAction);
+    const secondPromise = queue.enqueue(secondAction);
+
+    await flushMicrotasks();
+
+    expect(started).toEqual(['user-1']);
+    expect(executor.execute).toHaveBeenCalledTimes(1);
+
+    releaseByUserId.get('user-1')?.();
+    await firstPromise;
+    await flushMicrotasks();
+
+    expect(started).toEqual(['user-1', 'user-2']);
+    expect(executor.execute).toHaveBeenCalledTimes(2);
+
+    releaseByUserId.get('user-2')?.();
+    await secondPromise;
+  });
+
+  it('서로 다른 room의 액션은 병렬 처리 가능해야 한다', async () => {
+    const started: string[] = [];
+    let resolveFirst!: () => void;
+    let resolveSecond!: () => void;
+
+    executor.execute.mockImplementation((action) => {
+      started.push(action.roomId);
+
+      return new Promise<void>((resolve) => {
+        if (action.roomId === 'room-1') {
+          resolveFirst = resolve;
+          return;
+        }
+
+        resolveSecond = resolve;
+      });
+    });
+
+    const firstPromise = queue.enqueue(createDrawAction('room-1', 'user-1'));
+    const secondPromise = queue.enqueue(createDrawAction('room-2', 'user-2'));
+
+    await flushMicrotasks();
+
+    expect(started).toEqual(['room-1', 'room-2']);
+    expect(executor.execute).toHaveBeenCalledTimes(2);
+
+    resolveFirst();
+    resolveSecond();
+
+    await Promise.all([firstPromise, secondPromise]);
+  });
+
+  it('같은 room에 enqueue가 연속 호출돼도 processor는 하나만 실행되어야 한다', async () => {
+    let activeExecutions = 0;
+    let maxActiveExecutions = 0;
+    const releases: Array<() => void> = [];
+
+    executor.execute.mockImplementation(() => {
+      activeExecutions += 1;
+      maxActiveExecutions = Math.max(
+        maxActiveExecutions,
+        activeExecutions,
+      );
+
+      return new Promise<void>((resolve) => {
+        releases.push(() => {
+          activeExecutions -= 1;
+          resolve();
+        });
+      });
+    });
+
+    const firstPromise = queue.enqueue(createDrawAction('room-1', 'user-1'));
+    const secondPromise = queue.enqueue(createDrawAction('room-1', 'user-2'));
+    const thirdPromise = queue.enqueue(createDrawAction('room-1', 'user-3'));
+
+    await flushMicrotasks();
+    expect(maxActiveExecutions).toBe(1);
+    expect(executor.execute).toHaveBeenCalledTimes(1);
+
+    releases.shift()?.();
+    await firstPromise;
+    await flushMicrotasks();
+    expect(maxActiveExecutions).toBe(1);
+    expect(executor.execute).toHaveBeenCalledTimes(2);
+
+    releases.shift()?.();
+    await secondPromise;
+    await flushMicrotasks();
+    expect(maxActiveExecutions).toBe(1);
+    expect(executor.execute).toHaveBeenCalledTimes(3);
+
+    releases.shift()?.();
+    await thirdPromise;
+    expect(maxActiveExecutions).toBe(1);
+  });
+});
+
+function createDrawAction(roomId: string, userId: string): GameAction {
+  return {
+    type: GameActionType.DRAW_CARD,
+    roomId,
+    userId,
+    expectedActionId: 0,
+  };
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}

--- a/src/modules/game/actions/in-memory-game-action-queue.service.ts
+++ b/src/modules/game/actions/in-memory-game-action-queue.service.ts
@@ -1,0 +1,77 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+
+import { GameActionQueue } from './game-action-queue.interface';
+import { GAME_ACTION_EXECUTOR } from './game-action.token';
+import { GameAction } from 'src/shared/interfaces/game-action.interface';
+import type { GameActionExecutor } from './game-action-executor.interface';
+
+interface QueuedGameAction {
+  action: GameAction;
+  resolve: () => void;
+  reject: (error: unknown) => void;
+}
+
+@Injectable()
+export class InMemoryGameActionQueue implements GameActionQueue {
+  private readonly logger = new Logger(InMemoryGameActionQueue.name);
+  private readonly roomQueues = new Map<string, QueuedGameAction[]>();
+  private readonly activeProcessors = new Set<string>();
+
+  constructor(
+    @Inject(GAME_ACTION_EXECUTOR)
+    private readonly executor: GameActionExecutor,
+  ) {}
+
+  enqueue(action: GameAction): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      const roomQueue = this.roomQueues.get(action.roomId) ?? [];
+      roomQueue.push({ action, resolve, reject });
+      this.roomQueues.set(action.roomId, roomQueue);
+
+      if (!this.activeProcessors.has(action.roomId)) {
+        this.activeProcessors.add(action.roomId);
+        void this.processRoomQueue(action.roomId);
+      }
+    });
+  }
+
+  private async processRoomQueue(roomId: string): Promise<void> {
+    try {
+      while (true) {
+        const roomQueue = this.roomQueues.get(roomId);
+        const queuedAction = roomQueue?.shift();
+
+        if (!queuedAction) {
+          this.roomQueues.delete(roomId);
+          return;
+        }
+
+        try {
+          await this.executor.execute(queuedAction.action);
+          queuedAction.resolve();
+        } catch (error) {
+          const message =
+            error instanceof Error
+              ? error.stack ?? error.message
+              : JSON.stringify(error);
+
+          this.logger.error(
+            `Failed to execute action ${queuedAction.action.type} for room ${roomId} by user ${queuedAction.action.userId}: ${message}`,
+          );
+          queuedAction.reject(error);
+        }
+
+        if ((roomQueue?.length ?? 0) === 0) {
+          this.roomQueues.delete(roomId);
+        }
+      }
+    } finally {
+      this.activeProcessors.delete(roomId);
+
+      if ((this.roomQueues.get(roomId)?.length ?? 0) > 0) {
+        this.activeProcessors.add(roomId);
+        void this.processRoomQueue(roomId);
+      }
+    }
+  }
+}

--- a/src/modules/game/game.service.spec.ts
+++ b/src/modules/game/game.service.spec.ts
@@ -383,7 +383,7 @@ describe('GameService (Unit)', () => {
       expect(room.lastActionId).toBe(0);
     });
 
-    it('검증 통과 후 hand/discard/turn/lastActionId를 반영하고 로깅해야 한다', () => {
+    it('검증 통과 후 hand/discard/turn을 반영하고 로깅해야 한다', () => {
       const updatedRoom = service.playCard(host.userId, hostCard.id);
 
       const updatedHost = updatedRoom.players.find(
@@ -399,7 +399,7 @@ describe('GameService (Unit)', () => {
           updatedRoom.discardPile.length - 1
         ]?.id,
       ).toBe(hostCard.id);
-      expect(updatedRoom.lastActionId).toBe(1);
+      expect(updatedRoom.lastActionId).toBe(0);
       expect(updatedRoom.turnOwner).toBe(guest.userId);
       expect(roomService.pushLog).toHaveBeenCalledTimes(1);
     });
@@ -666,7 +666,7 @@ describe('GameService (Unit)', () => {
 
     });
 
-    it('drawPile의 맨 앞 카드를 호출한 플레이어 hand에 추가하고 턴/액션/로그를 갱신해야 한다', () => {
+    it('drawPile의 맨 앞 카드를 호출한 플레이어 hand에 추가하고 턴/로그를 갱신해야 한다', () => {
       const updatedRoom = service.drawCard(
         host.userId,
         room.roomId,
@@ -680,7 +680,7 @@ describe('GameService (Unit)', () => {
       expect(updatedHost.cardCount).toBe(1);
       expect(updatedRoom.drawPile).toEqual([]);
       expect(updatedRoom.turnOwner).toBe(guest.userId);
-      expect(updatedRoom.lastActionId).toBe(1);
+      expect(updatedRoom.lastActionId).toBe(0);
       expect(roomService.pushLog).toHaveBeenCalledWith(
         updatedRoom,
         expect.objectContaining({

--- a/src/modules/game/game.service.ts
+++ b/src/modules/game/game.service.ts
@@ -181,8 +181,6 @@ export class GameService {
     });
     this.pushPlayCardLog(room, player, card);
 
-    room.lastActionId += 1;
-
     return room;
   }
 
@@ -210,7 +208,6 @@ export class GameService {
       room,
       player,
     });
-    room.lastActionId += 1;
     this.pushDrawCardLog(room, player, card);
 
     return room;

--- a/src/modules/socket/dto/game-room.dto.ts
+++ b/src/modules/socket/dto/game-room.dto.ts
@@ -1,4 +1,4 @@
-import { IsBoolean, IsDefined, IsEnum, IsNotEmpty, IsOptional, IsString, IsUUID } from "class-validator";
+import { IsEnum, IsInt, IsNotEmpty, IsOptional, IsString, IsUUID, Min } from "class-validator";
 import { CardSuit } from "src/shared/enums/game.enum";
 
 export class RoomIdDto {
@@ -8,13 +8,19 @@ export class RoomIdDto {
   roomId!: string;
 }
 
+export class ActionDto extends RoomIdDto {
+  @IsInt({ message: 'expectedActionId는 정수여야 합니다.' })
+  @Min(0, { message: 'expectedActionId는 0 이상이어야 합니다.' })
+  expectedActionId!: number;
+}
+
 export class JoinRoomDto extends RoomIdDto {}
 
 /**
  * 단일 방 정책이어도
  * 재접속/상태복구/이벤트 명시성을 위해 roomId 유지한다.
  */
-export class PlayCardDto extends RoomIdDto {
+export class PlayCardDto extends ActionDto {
   @IsUUID('4', { message: '카드 ID는 유효한 UUID v4 형식이어야 합니다.' })
   @IsNotEmpty({ message: '낼 카드의 ID가 필요합니다.' })
   cardId!: string;

--- a/src/modules/socket/dto/game-room.response.dto.spec.ts
+++ b/src/modules/socket/dto/game-room.response.dto.spec.ts
@@ -40,6 +40,32 @@ describe('GameRoomResponseDto', () => {
     expect(serialized.discardPile).toBeUndefined();
   });
 
+  it('lastActionId는 직렬화 시 포함되어야 한다', () => {
+    const room: GameRoom = {
+      roomId: 'room-1',
+      hostId: 'me',
+      attackStack: 0,
+      currentPower: 0,
+      lastCard: createMockCard(),
+      drawPile: [],
+      discardPile: [],
+      lastActionId: 7,
+      turnOwner: 'me',
+      isBonusTurn: false,
+      direction: GameDirection.CLOCKWISE,
+      status: 'PLAYING',
+      recentLogs: [],
+      players: [],
+    };
+
+    const dto = plainToInstance(GameRoomResponseDto, room, {
+      excludeExtraneousValues: true,
+    });
+    const serialized = JSON.parse(JSON.stringify(dto));
+
+    expect(serialized.lastActionId).toBe(7);
+  });
+
 });
 
 function createMockCard(overrides?: Partial<Card>): Card {

--- a/src/modules/socket/dto/game-room.response.dto.ts
+++ b/src/modules/socket/dto/game-room.response.dto.ts
@@ -31,6 +31,7 @@ export class GameRoomResponseDto {
   @Expose() isBonusTurn!: boolean;
   @Expose() direction!: GameDirection;
   @Expose() attackStack!: number;
+  @Expose() lastActionId!: number;
   @Expose()
   @Type(() => GameLogResponseDto)
   recentLogs!: GameLogResponseDto[];

--- a/src/modules/socket/dto/play-card.dto.spec.ts
+++ b/src/modules/socket/dto/play-card.dto.spec.ts
@@ -6,7 +6,8 @@ describe('PlayCardDto', () => {
   it('roomId와 cardId가 모두 유효한 UUID v4 형식이면 통과해야 한다', async () => {
     const target = {
       roomId: '550e8400-e29b-41d4-a716-446655440000',
-      cardId: '770e8400-e29b-41d4-a716-446655441111'
+      cardId: '770e8400-e29b-41d4-a716-446655441111',
+      expectedActionId: 0,
     };
     const dto = plainToInstance(PlayCardDto, target);
     const errors = await validate(dto);
@@ -17,7 +18,8 @@ describe('PlayCardDto', () => {
   it('cardId가 UUID 형식이 아니면 유효성 검사에 실패해야 한다', async () => {
     const target = {
       roomId: '550e8400-e29b-41d4-a716-446655440000',
-      cardId: 'invalid-card-id'
+      cardId: 'invalid-card-id',
+      expectedActionId: 0,
     };
     const dto = plainToInstance(PlayCardDto, target);
     const errors = await validate(dto);
@@ -28,7 +30,8 @@ describe('PlayCardDto', () => {
 
   it('cardId가 누락되면 유효성 검사에 실패해야 한다', async () => {
     const target = {
-      roomId: '550e8400-e29b-41d4-a716-446655440000'
+      roomId: '550e8400-e29b-41d4-a716-446655440000',
+      expectedActionId: 0,
     };
     const dto = plainToInstance(PlayCardDto, target);
     const errors = await validate(dto);
@@ -41,6 +44,7 @@ describe('PlayCardDto', () => {
     const target = {
       roomId: '550e8400-e29b-41d4-a716-446655440000',
       cardId: '770e8400-e29b-41d4-a716-446655441111',
+      expectedActionId: 0,
       chosenSuit: 'CAT',
     };
     const dto = plainToInstance(PlayCardDto, target);
@@ -53,6 +57,7 @@ describe('PlayCardDto', () => {
     const target = {
       roomId: '550e8400-e29b-41d4-a716-446655440000',
       cardId: '770e8400-e29b-41d4-a716-446655441111',
+      expectedActionId: 0,
       chosenSuit: 'INVALID',
     };
     const dto = plainToInstance(PlayCardDto, target);
@@ -60,5 +65,30 @@ describe('PlayCardDto', () => {
 
     expect(errors.length).toBeGreaterThan(0);
     expect(errors[0].property).toBe('chosenSuit');
+  });
+
+  it('expectedActionId가 누락되면 유효성 검사에 실패해야 한다', async () => {
+    const target = {
+      roomId: '550e8400-e29b-41d4-a716-446655440000',
+      cardId: '770e8400-e29b-41d4-a716-446655441111',
+    };
+    const dto = plainToInstance(PlayCardDto, target);
+    const errors = await validate(dto);
+
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors.some((error) => error.property === 'expectedActionId')).toBe(true);
+  });
+
+  it('expectedActionId가 음수면 유효성 검사에 실패해야 한다', async () => {
+    const target = {
+      roomId: '550e8400-e29b-41d4-a716-446655440000',
+      cardId: '770e8400-e29b-41d4-a716-446655441111',
+      expectedActionId: -1,
+    };
+    const dto = plainToInstance(PlayCardDto, target);
+    const errors = await validate(dto);
+
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors.some((error) => error.property === 'expectedActionId')).toBe(true);
   });
 });

--- a/src/modules/socket/game.gateway.spec.ts
+++ b/src/modules/socket/game.gateway.spec.ts
@@ -17,27 +17,32 @@ import { GameParticipantGuard } from 'src/common/guards/game-participant.guard';
 import { TurnOwnerGuard } from 'src/common/guards/turnowner.guard';
 import { GameResponseInterceptor } from './interceptors/game-response.interceptor';
 import { TurnManagerService } from '../game/turn-manager.service';
+import { GameActionQueue } from '../game/actions/game-action-queue.interface';
+import { GameActionType } from 'src/shared/enums/game-action-type.enum';
 
 describe('GameGateway', () => {
   let gateway: GameGateway;
   let authService: jest.Mocked<AuthService>;
   let roomService: jest.Mocked<RoomService>;
   let gameService: jest.Mocked<GameService>;
+  let gameActionQueue: jest.Mocked<GameActionQueue>;
 
   beforeEach(() => {
     authService = createMock<AuthService>();
     roomService = createMock<RoomService>();
     gameService = createMock<GameService>();
+    gameActionQueue = createMock<GameActionQueue>();
 
     gateway = new GameGateway(
       authService,
       roomService,
       gameService,
+      gameActionQueue,
     );
   });
 
   describe('handlePlayCard', () => {
-    it('playCard 이벤트에서 GameService.playCard를 호출해야 한다', () => {
+    it('playCard 이벤트에서 Queue에 액션을 enqueue하고 후조회한 room을 반환해야 한다', async () => {
       const client = {
         data: {
           user: {
@@ -61,7 +66,8 @@ describe('GameGateway', () => {
         }
       };
 
-      gameService.playCard.mockReturnValue(
+      gameActionQueue.enqueue.mockResolvedValue(undefined);
+      roomService.getRoom.mockReturnValue(
         updatedRoom as GameRoom,
       );
 
@@ -72,18 +78,24 @@ describe('GameGateway', () => {
 
       gateway.server = { to } as unknown as Server;
 
-      const result = gateway.handlePlayCard(
+      const result = await gateway.handlePlayCard(
         client,
         {
           roomId: 'room-1',
           cardId: 'card-1',
+          expectedActionId: 0,
         },
       );
 
-      expect(gameService.playCard).toHaveBeenCalledWith(
-        'user-1',
-        'card-1',
-        undefined,
+      expect(gameActionQueue.enqueue).toHaveBeenCalledWith(
+        {
+          type: GameActionType.PLAY_CARD,
+          roomId: 'room-1',
+          userId: 'user-1',
+          expectedActionId: 0,
+          cardId: 'card-1',
+          chosenSuit: undefined,
+        },
       );
       expect(to).toHaveBeenCalledWith(
         'room-1',
@@ -97,7 +109,7 @@ describe('GameGateway', () => {
       expect(result).toBe(updatedRoom);
     });
 
-    it('서비스에서 발생한 예외를 그대로 전파해야 한다', () => {
+    it('Queue에서 발생한 예외를 그대로 전파해야 한다', async () => {
       const client = {
         data: {
           user: {
@@ -108,10 +120,8 @@ describe('GameGateway', () => {
         },
       } as Socket;
 
-      gameService.playCard.mockImplementation(
-        () => {
-          throw new WsException('play card failed');
-        },
+      gameActionQueue.enqueue.mockRejectedValue(
+        new WsException('play card failed'),
       );
 
       gateway.server = {
@@ -120,20 +130,21 @@ describe('GameGateway', () => {
         }),
       } as unknown as Server;
 
-      expect(() =>
+      await expect(
         gateway.handlePlayCard(
           client,
           {
             roomId: 'room-1',
             cardId: 'card-1',
+            expectedActionId: 0,
           },
         ),
-      ).toThrow(WsException);
+      ).rejects.toThrow(WsException);
     });
   });
 
   describe('handleDrawCard', () => {
-    it('drawCard 이벤트에서 GameService.drawCard를 호출해야 한다', () => {
+    it('drawCard 이벤트에서 Queue에 액션을 enqueue하고 후조회한 room을 반환해야 한다', async () => {
       const client = {
         data: {
           user: {
@@ -148,7 +159,8 @@ describe('GameGateway', () => {
         roomId: 'room-1',
       };
 
-      gameService.drawCard.mockReturnValue(
+      gameActionQueue.enqueue.mockResolvedValue(undefined);
+      roomService.getRoom.mockReturnValue(
         updatedRoom as GameRoom,
       );
 
@@ -159,16 +171,21 @@ describe('GameGateway', () => {
 
       gateway.server = { to } as unknown as Server;
 
-      const result = gateway.handleDrawCard(
+      const result = await gateway.handleDrawCard(
         client,
         {
           roomId: 'room-1',
+          expectedActionId: 0,
         },
       );
 
-      expect(gameService.drawCard).toHaveBeenCalledWith(
-        'user-1',
-        'room-1',
+      expect(gameActionQueue.enqueue).toHaveBeenCalledWith(
+        {
+          type: GameActionType.DRAW_CARD,
+          roomId: 'room-1',
+          userId: 'user-1',
+          expectedActionId: 0,
+        },
       );
       expect(to).toHaveBeenCalledWith(
         'room-1',
@@ -182,7 +199,7 @@ describe('GameGateway', () => {
       expect(result).toBe(updatedRoom);
     });
 
-    it('서비스에서 발생한 예외를 그대로 전파해야 한다', () => {
+    it('Queue에서 발생한 예외를 그대로 전파해야 한다', async () => {
       const client = {
         data: {
           user: {
@@ -193,10 +210,8 @@ describe('GameGateway', () => {
         },
       } as Socket;
 
-      gameService.drawCard.mockImplementation(
-        () => {
-          throw new WsException('draw card failed');
-        },
+      gameActionQueue.enqueue.mockRejectedValue(
+        new WsException('draw card failed'),
       );
 
       gateway.server = {
@@ -205,17 +220,18 @@ describe('GameGateway', () => {
         }),
       } as unknown as Server;
 
-      expect(() =>
+      await expect(
         gateway.handleDrawCard(
           client,
           {
             roomId: 'room-1',
+            expectedActionId: 0,
           },
         ),
-      ).toThrow(WsException);
+      ).rejects.toThrow(WsException);
     });
 
-    it('payload roomId를 GameService.drawCard로 전달해야 한다', () => {
+    it('payload roomId와 expectedActionId를 Queue 액션으로 전달해야 한다', async () => {
       const client = {
         data: {
           user: {
@@ -226,7 +242,8 @@ describe('GameGateway', () => {
         },
       } as Socket;
 
-      gameService.drawCard.mockReturnValue({
+      gameActionQueue.enqueue.mockResolvedValue(undefined);
+      roomService.getRoom.mockReturnValue({
         roomId: 'room-other',
       } as GameRoom);
 
@@ -236,17 +253,20 @@ describe('GameGateway', () => {
         }),
       } as unknown as Server;
 
-      gateway.handleDrawCard(
+      await gateway.handleDrawCard(
         client,
         {
           roomId: 'room-other',
+          expectedActionId: 3,
         },
       );
 
-      expect(gameService.drawCard).toHaveBeenCalledWith(
-        'user-1',
-        'room-other',
-      );
+      expect(gameActionQueue.enqueue).toHaveBeenCalledWith({
+        type: GameActionType.DRAW_CARD,
+        roomId: 'room-other',
+        userId: 'user-1',
+        expectedActionId: 3,
+      });
     });
 
     it('GameParticipantGuard와 TurnOwnerGuard, GameResponseInterceptor가 적용되어야 한다', () => {
@@ -285,11 +305,13 @@ describe('GameGateway disconnect cleanup', () => {
     gameService = createMock<GameService>();
     turnManager = createMock<TurnManagerService>();
     roomService = new RoomService(turnManager);
+    gameActionQueue = createMock<GameActionQueue>();
 
     gateway = new GameGateway(
       authService,
       roomService,
       gameService,
+      gameActionQueue,
     );
 
     gateway.server = {

--- a/src/modules/socket/game.gateway.ts
+++ b/src/modules/socket/game.gateway.ts
@@ -9,20 +9,23 @@ import {
   MessageBody,
   WsException,
 } from '@nestjs/websockets';
-import { Logger, UseFilters, UseGuards, UseInterceptors, UsePipes, ValidationPipe } from '@nestjs/common';
+import { Inject, Logger, UseFilters, UseGuards, UseInterceptors, UsePipes, ValidationPipe } from '@nestjs/common';
 import { Server, Socket, SocketData } from 'socket.io';
-import { JoinRoomDto, PlayCardDto, RoomIdDto } from './dto/game-room.dto';
+import { ActionDto, JoinRoomDto, PlayCardDto } from './dto/game-room.dto';
 import { SocketEvent } from 'src/shared/enums/socket-event.enum';
 import { SocketAuthMiddleware } from './middlewares/auth.middleware';
 import { WsExceptionFilter } from 'src/common/filters/ws-exception.filter';
 import { AuthService } from '../auth/auth.service';
-import { RoomService } from './room.service';
 import { GameService } from '../game/game.service';
+import { RoomService } from './room.service';
 import { GameResponseInterceptor } from './interceptors/game-response.interceptor';
 import { GameParticipantGuard } from 'src/common/guards/game-participant.guard';
 import { TurnOwnerGuard } from 'src/common/guards/turnowner.guard';
 import { RoomMasterGuard } from 'src/common/guards/room-master.guard';
 import { MemberOnlyGuard } from 'src/common/guards/member-only.guard';
+import { GAME_ACTION_QUEUE } from '../game/actions/game-action.token';
+import { GameActionType } from 'src/shared/enums/game-action-type.enum';
+import type { GameActionQueue } from '../game/actions/game-action-queue.interface';
 
 // 기본 ValidationPipe는 HTTP 예외를 던지므로, WebSocket에 맞게 커스텀 설정
 export const SocketValidationConfig = new ValidationPipe({
@@ -48,6 +51,8 @@ export class GameGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
     private readonly authService: AuthService,
     private readonly roomService: RoomService,
     private readonly gameService: GameService,
+    @Inject(GAME_ACTION_QUEUE)
+    private readonly gameActionQueue: GameActionQueue,
   ) {}
 
   @UseGuards(MemberOnlyGuard)
@@ -128,18 +133,27 @@ export class GameGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
   @UseGuards(GameParticipantGuard, TurnOwnerGuard)
   @UseInterceptors(GameResponseInterceptor)
   @SubscribeMessage(SocketEvent.PLAY_CARD)
-  handlePlayCard(
+  async handlePlayCard(
     @ConnectedSocket() client: Socket,
     @MessageBody() data: PlayCardDto,
   ) {
     this.logger.log(
       `[${SocketEvent.PLAY_CARD}] 유저 ${client.data.user.nickname}(${client.data.user.userId})가 방(${data.roomId})에 카드(${data.cardId}) 제출 시도`
     );
-    const updatedRoom = this.gameService.playCard(
-      client.data.user.userId,
-      data.cardId,
-      data.chosenSuit,
-    );
+    await this.gameActionQueue.enqueue({
+      type: GameActionType.PLAY_CARD,
+      roomId: data.roomId,
+      userId: client.data.user.userId,
+      expectedActionId: data.expectedActionId,
+      cardId: data.cardId,
+      chosenSuit: data.chosenSuit,
+    });
+
+    const updatedRoom = this.roomService.getRoom(data.roomId);
+
+    if (!updatedRoom) {
+      throw new WsException('Room not found');
+    }
 
     this.server
       .to(updatedRoom.roomId)
@@ -156,18 +170,26 @@ export class GameGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
   @UseGuards(GameParticipantGuard, TurnOwnerGuard)
   @UseInterceptors(GameResponseInterceptor)
   @SubscribeMessage(SocketEvent.DRAW_CARD)
-  handleDrawCard(
+  async handleDrawCard(
     @ConnectedSocket() client: Socket,
-    @MessageBody() data: RoomIdDto,
+    @MessageBody() data: ActionDto,
   ) {
     this.logger.log(
       `[${SocketEvent.DRAW_CARD}] 유저 ${client.data.user.nickname}(${client.data.user.userId})가 방(${data.roomId})에서 카드 드로우 시도`
     );
 
-    const updatedRoom = this.gameService.drawCard(
-      client.data.user.userId,
-      data.roomId,
-    );
+    await this.gameActionQueue.enqueue({
+      type: GameActionType.DRAW_CARD,
+      roomId: data.roomId,
+      userId: client.data.user.userId,
+      expectedActionId: data.expectedActionId,
+    });
+
+    const updatedRoom = this.roomService.getRoom(data.roomId);
+
+    if (!updatedRoom) {
+      throw new WsException('Room not found');
+    }
 
     this.server
       .to(updatedRoom.roomId)

--- a/src/modules/socket/game.module.ts
+++ b/src/modules/socket/game.module.ts
@@ -17,6 +17,9 @@ import { EvadeCardValidator } from "../game/validators/evade-card-action.validat
 import { BonusCardValidator } from "../game/validators/bonus-card-action.validator";
 import { WildcardActionValidator } from "../game/validators/wildcard-action.validator";
 import { TurnManagerService } from "../game/turn-manager.service";
+import { GAME_ACTION_EXECUTOR, GAME_ACTION_QUEUE } from "../game/actions/game-action.token";
+import { GameActionExecutorService } from "../game/actions/game-action-executor.service";
+import { InMemoryGameActionQueue } from "../game/actions/in-memory-game-action-queue.service";
 
 @Module({
   imports: [AuthModule],
@@ -37,6 +40,16 @@ import { TurnManagerService } from "../game/turn-manager.service";
     BonusCardValidator,
     WildcardActionValidator,
     TurnManagerService,
+    GameActionExecutorService,
+    InMemoryGameActionQueue,
+    {
+      provide: GAME_ACTION_EXECUTOR,
+      useExisting: GameActionExecutorService,
+    },
+    {
+      provide: GAME_ACTION_QUEUE,
+      useExisting: InMemoryGameActionQueue,
+    },
     {
       provide: ACTION_VALIDATORS,
       useFactory: (

--- a/src/shared/enums/game-action-type.enum.ts
+++ b/src/shared/enums/game-action-type.enum.ts
@@ -1,0 +1,4 @@
+export enum GameActionType {
+  PLAY_CARD = 'PLAY_CARD',
+  DRAW_CARD = 'DRAW_CARD',
+}

--- a/src/shared/enums/game-error-code.enum.ts
+++ b/src/shared/enums/game-error-code.enum.ts
@@ -1,0 +1,3 @@
+export enum GameErrorCode {
+  GAME_STATE_OUTDATED = 'GAME_STATE_OUTDATED',
+}

--- a/src/shared/interfaces/game-action.interface.ts
+++ b/src/shared/interfaces/game-action.interface.ts
@@ -1,0 +1,21 @@
+import { CardSuit } from '../enums/game.enum';
+import { GameActionType } from '../enums/game-action-type.enum';
+
+interface BaseGameAction {
+  type: GameActionType;
+  roomId: string;
+  userId: string;
+  expectedActionId: number;
+}
+
+export interface PlayCardAction extends BaseGameAction {
+  type: GameActionType.PLAY_CARD;
+  cardId: string;
+  chosenSuit?: CardSuit;
+}
+
+export interface DrawCardAction extends BaseGameAction {
+  type: GameActionType.DRAW_CARD;
+}
+
+export type GameAction = PlayCardAction | DrawCardAction;


### PR DESCRIPTION
## 🚀 개요

동일 Room에서 거의 동시에 들어오는 액션이 동일한 상태를 기준으로 검증을 통과할 수 있는 문제를 해결하기 위해, Room 단위 액션 직렬화와 `lastActionId` 기반 상태 버전 검증을 도입했습니다.

기존 `Gateway -> GameService` 직접 호출 구조를 `Gateway -> Queue -> Executor -> GameService`로 전환하여 stale request를 명확히 판별하고 액션 실행의 정합성을 보장하도록 개선했습니다.

## ✨ 주요 작업 내용

### 🧱 액션 추상화 및 버전 계약 추가
- `GameAction`, `GameActionType` 도입
- `PLAY_CARD`, `DRAW_CARD`를 공통 액션 모델로 통합
- 요청 DTO에 `expectedActionId` 추가
- 응답 DTO에 `lastActionId` 노출

### 🧵 Room 단위 액션 직렬화 도입
- `GameActionQueue` 인터페이스 추가
- `InMemoryGameActionQueue` 구현
- Room별 큐와 단일 processor 실행 보장
- 동일 Room 액션은 순차 처리, 서로 다른 Room은 병렬 처리 가능하도록 구성

### 🛡️ 실행 직전 정합성 검증 계층 분리
- `GameActionExecutorService` 추가
- 액션 실행 직전에 아래 항목 재검증
  - `expectedActionId === room.lastActionId`
  - 현재 턴 소유자 여부
  - 플레이 가능 상태 여부
- stale action 발생 시 `GAME_STATE_OUTDATED` 반환

### 🔀 Gateway 처리 흐름 전환
- `playCard`, `drawCard`를 Queue 기반으로 전환
- `await queue.enqueue(action)` 이후 Room 후조회
- 처리 완료 후에만 상태 브로드캐스트 수행
- 기존 WebSocket 요청-응답 흐름은 유지

### 🧼 책임 분리 정리
- `GameService`에서 `lastActionId` 증가 책임 제거
- `lastActionId` 증가는 Executor가 담당
- `GameService`는 게임 도메인 처리에만 집중하도록 정리

### 🧪 테스트 보강
- 같은 Room 액션 순차 처리 검증
- 다른 Room 병렬 처리 검증
- stale action rejection 검증
- executor의 turn/version 재검증 테스트 추가
- DTO/응답 계약 테스트 보강
- gateway가 queue 기반으로 동작하는지 테스트 갱신

## 🎯 핵심 설계 포인트

### 1. Guard 통과와 실행 성공을 분리
`TurnOwnerGuard`는 fail-fast 용도로만 유지하고,  
최종 정합성은 Executor가 최신 Room 상태 기준으로 다시 판단합니다.

### 2. Queue는 “적재 완료”가 아니라 “처리 완료” 시 resolve
`enqueue(): Promise<void>` 계약은 유지하면서
Queue는 단순 적재가 아닌 액션 실행 완료 시점에 resolve되도록 구현하여,
기존 WebSocket 요청-응답 흐름을 유지하면서도 Room 단위 직렬 처리를 보장했습니다.

### 3. 현재는 In-Memory, 구조는 교체 가능하게
Queue를 인터페이스로 추상화해 두어,  
향후 Redis 기반 구현으로 교체할 때 Gateway/Executor 계약을 유지할 수 있게 설계했습니다.

### 4. 과한 패턴 대신 단순 분기 구조 유지
액션별 클래스 남발 없이 `type` 기반 분기로 처리해,  
현재 지원 범위(`PLAY_CARD`, `DRAW_CARD`)에 맞는 YAGNI 지향 구조를 유지했습니다.

## 📌 참고
- `GAME_STATE_OUTDATED`는 에러 코드로 응답되도록 보강했습니다.
- `WsException` 에러코드 체계 일반화는 후속 티켓 `ANI-29` TODO로 남겨두었습니다.