### PR TITLE
fix: align bonus draw turn flow

### DIFF
--- a/src/modules/game/game.service.spec.ts
+++ b/src/modules/game/game.service.spec.ts
@@ -596,8 +596,19 @@ describe('GameService (Unit)', () => {
         value: 'BONUS',
         suit: CardSuit.RABBIT,
       });
+      const extraCard = createMockCard({
+        id: uuidv4(),
+        type: CardType.NUMBER,
+        value: '4',
+        suit: CardSuit.CAT,
+      });
 
-      setHostCardForPlay(bonusCard);
+      const hostPlayer = room.players.find(
+        p => p.userId === host.userId,
+      )!;
+      room.turnOwner = host.userId;
+      hostPlayer.hand = [bonusCard, extraCard];
+      hostPlayer.cardCount = 2;
       turnManager.applyTurnEffect.mockImplementation(
         ({ room: targetRoom, playerId }) => {
           targetRoom.turnOwner = playerId;
@@ -610,6 +621,76 @@ describe('GameService (Unit)', () => {
 
       expect(room.turnOwner).toBe(host.userId);
       expect(room.isBonusTurn).toBe(true);
+    });
+
+    it('마지막 hand 가 BONUS 카드면 승리하지 않고 1장을 자동 드로우해야 한다', () => {
+      const bonusCard = createMockCard({
+        id: uuidv4(),
+        type: CardType.SPECIAL,
+        value: 'BONUS',
+        suit: CardSuit.RABBIT,
+      });
+      const autoDrawCard = createMockCard({
+        id: uuidv4(),
+        type: CardType.NUMBER,
+        value: '8',
+        suit: CardSuit.CAT,
+      });
+
+      room.drawPile = [autoDrawCard];
+      setHostCardForPlay(bonusCard);
+      turnManager.resolveTurnAfterDraw.mockImplementation(
+        ({ room: targetRoom }) => {
+          targetRoom.turnOwner = guest.userId;
+          return guest.userId;
+        },
+      );
+
+      service.playCard(host.userId, bonusCard.id);
+
+      const updatedHost = room.players.find(
+        (player) => player.userId === host.userId,
+      )!;
+
+      expect(victoryService.determineWinner).not.toHaveBeenCalled();
+      expect(updatedHost.hand).toEqual([autoDrawCard]);
+      expect(updatedHost.cardCount).toBe(1);
+      expect(room.status).toBe(GameStatus.PLAYING);
+      expect(room.winnerId).toBeNull();
+      expect(room.turnOwner).toBe(guest.userId);
+      expect(room.isBonusTurn).toBe(false);
+      expect(turnManager.resolveTurnAfterDraw).toHaveBeenCalledWith(
+        expect.objectContaining({
+          room,
+          player: expect.objectContaining({
+            userId: host.userId,
+            hand: [autoDrawCard],
+            cardCount: 1,
+          }),
+        }),
+      );
+      expect(turnManager.applyTurnEffect).not.toHaveBeenCalled();
+      expect(roomService.pushLog).toHaveBeenNthCalledWith(
+        1,
+        room,
+        expect.objectContaining({
+          type: LogType.BONUS,
+          actorId: host.userId,
+          cardId: bonusCard.id,
+        }),
+      );
+      expect(roomService.pushLog).toHaveBeenNthCalledWith(
+        2,
+        room,
+        expect.objectContaining({
+          type: LogType.DRAW,
+          actorId: host.userId,
+          cardId: autoDrawCard.id,
+          payload: expect.objectContaining({
+            drawCount: 1,
+          }),
+        }),
+      );
     });
 
     it('REVERSE 카드면 진행 방향을 반전해야 한다', () => {
@@ -781,6 +862,18 @@ describe('GameService (Unit)', () => {
           }),
         }),
       );
+    });
+
+    it('BONUS 상태에서 드로우하면 bonusTurn을 해제하고 턴을 넘겨야 한다', () => {
+      room.isBonusTurn = true;
+
+      const updatedRoom = service.drawCard(
+        host.userId,
+        room.roomId,
+      );
+
+      expect(updatedRoom.isBonusTurn).toBe(false);
+      expect(updatedRoom.turnOwner).toBe(guest.userId);
     });
 
     it('요청 roomId가 서버 세션의 roomId와 다르면 예외가 발생해야 한다', () => {

--- a/src/modules/game/game.service.ts
+++ b/src/modules/game/game.service.ts
@@ -184,12 +184,20 @@ export class GameService {
     player.cardCount = player.hand.length;
 
     this.pushToDiscardPile(room, card);
-    const victory =
-      this.victoryService.determineWinner({
+    const autoDrawnCards =
+      this.handleBonusLastCardPolicy(
         room,
-        trigger: VictoryTrigger.CARD_PLAYED,
-        actorId: player.userId,
-      });
+        player,
+        card,
+      );
+    const victory =
+      autoDrawnCards.length === 0
+        ? this.victoryService.determineWinner({
+          room,
+          trigger: VictoryTrigger.CARD_PLAYED,
+          actorId: player.userId,
+        })
+        : null;
 
     if (victory) {
       this.finishGame(room, victory);
@@ -197,17 +205,58 @@ export class GameService {
     }
 
     this.applyCardStateEffect(room, card);
-    this.turnManager.applyTurnEffect({
-      room,
-      playerId: player.userId,
-      effect: this.resolveTurnEffect(
+    if (autoDrawnCards.length === 0) {
+      this.turnManager.applyTurnEffect({
         room,
-        card,
-      ),
-    });
+        playerId: player.userId,
+        effect: this.resolveTurnEffect(
+          room,
+          card,
+        ),
+      });
+    }
     this.pushPlayCardLog(room, player, card);
+    if (autoDrawnCards.length > 0) {
+      this.pushDrawCardLog(
+        room,
+        player,
+        autoDrawnCards[
+          autoDrawnCards.length - 1
+        ],
+        autoDrawnCards.length,
+      );
+    }
 
     return room;
+  }
+
+  private handleBonusLastCardPolicy(
+    room: GameRoom,
+    player: Player,
+    card: Card,
+  ): Card[] {
+    const isBonusLastCard =
+      card.type === CardType.SPECIAL &&
+      card.value === 'BONUS' &&
+      player.hand.length === 0;
+
+    if (!isBonusLastCard) {
+      return [];
+    }
+
+    const drawnCards =
+      this.performDraw(
+        room,
+        player,
+        {
+          actorId: player.userId,
+          drawCount: 1,
+          shouldAdvanceTurn: true,
+          shouldClearBonusTurn: true,
+        },
+      );
+
+    return drawnCards;
   }
 
   drawCard(
@@ -227,25 +276,23 @@ export class GameService {
       ? room.attackStack
       : 1;
     const drawnCards =
-      this.drawCardsFromPile(
+      this.performDraw(
         room,
-        userId,
-        drawCount,
+        player,
+        {
+          actorId: userId,
+          drawCount,
+          shouldAdvanceTurn: true,
+          shouldClearBonusTurn:
+            isPenaltyDraw ||
+            room.isBonusTurn,
+        },
       );
-
-    player.hand.push(...drawnCards);
-    player.cardCount = player.hand.length;
 
     if (isPenaltyDraw) {
       room.attackStack = 0;
       room.currentPower = 0;
-      room.isBonusTurn = false;
     }
-
-    this.turnManager.resolveTurnAfterDraw({
-      room,
-      player,
-    });
     this.pushDrawCardLog(
       room,
       player,
@@ -254,6 +301,40 @@ export class GameService {
     );
 
     return room;
+  }
+
+  private performDraw(
+    room: GameRoom,
+    player: Player,
+    options: {
+      actorId: string;
+      drawCount: number;
+      shouldAdvanceTurn: boolean;
+      shouldClearBonusTurn: boolean;
+    },
+  ): Card[] {
+    const drawnCards =
+      this.drawCardsFromPile(
+        room,
+        options.actorId,
+        options.drawCount,
+      );
+
+    player.hand.push(...drawnCards);
+    player.cardCount = player.hand.length;
+
+    if (options.shouldClearBonusTurn) {
+      room.isBonusTurn = false;
+    }
+
+    if (options.shouldAdvanceTurn) {
+      this.turnManager.resolveTurnAfterDraw({
+        room,
+        player,
+      });
+    }
+
+    return drawnCards;
   }
 
   private drawCardsFromPile(


### PR DESCRIPTION
## 🧩 작업 배경
`BONUS` 카드 사용 후 드로우/턴 전환 흐름이 스펙과 어긋나던 부분을 정리했습니다.

특히 마지막 손패가 `BONUS`인 경우
- 승리로 끝나면 안 되고
- 1장 강제 드로우가 발생해야 하며
- 드로우 이후에는 턴이 넘어가야 하는 규칙을 서버 로직에 맞췄습니다.

## ✅ 주요 변경사항

### 🎴 BONUS 마지막 장 처리 보강
- 마지막 손패로 `BONUS`를 낸 경우 승리 판정을 바로 하지 않도록 조정
- 해당 상황에서는 강제 1드로우를 먼저 수행하도록 변경
- 강제 드로우가 발생한 경우 일반 `BONUS`의 추가 행동 효과는 적용하지 않도록 분기 처리

### 🔄 드로우 처리 공통화
- 카드 드로우 시 손패 반영, `bonusTurn` 정리, 턴 전환을 담당하는 내부 공통 루틴 추가
- 일반 `drawCard`와 `BONUS` 마지막 장 강제 드로우가 같은 흐름을 재사용하도록 정리
- `BONUS` 상태에서 드로우가 발생하면 턴이 넘어가도록 일관성 확보

### 🧼 bonusTurn 상태 정리
- `BONUS` 이후 자의적 드로우 시에도 `bonusTurn`이 남지 않도록 보정
- 강제 드로우/일반 드로우 모두에서 후속 턴 메타 상태가 꼬이지 않도록 정리

## 🧪 테스트
- 손패가 남아 있는 일반 `BONUS` 사용 시 턴 유지 검증
- 마지막 손패 `BONUS` 사용 시 자동 드로우 후 승리하지 않고 턴이 넘어가는지 검증
- `BONUS` 상태에서 드로우 시 `bonusTurn` 해제 및 턴 전환 검증

## 📌 기대 효과
- `BONUS` 카드의 피니시 악용 방지
- 드로우 이후 턴 처리 규칙의 일관성 확보
- `bonusTurn` 상태 누수로 인한 후속 판정 오류 가능성 감소