### PR TITLE
feat: [ANI-21] 전체 상태 동기화(snapshot) 모델 정비

### DIFF
--- a/src/modules/game/actions/game-action-executor.service.spec.ts
+++ b/src/modules/game/actions/game-action-executor.service.spec.ts
@@ -156,6 +156,7 @@ function createPlayer(userId: string): Player {
     hand: [],
     cardCount: 0,
     isReady: true,
+    isConnected: true,
     isOut: false,
     role: 'PLAYER',
   };

--- a/src/modules/game/game-setup.service.spec.ts
+++ b/src/modules/game/game-setup.service.spec.ts
@@ -104,6 +104,7 @@ describe('GameSetupService', () => {
       cardCount: 0,
       hand: [],
       isReady: true,
+      isConnected: true,
       isOut: false,
       role: 'PLAYER',
     });

--- a/src/modules/game/game.service.spec.ts
+++ b/src/modules/game/game.service.spec.ts
@@ -1179,6 +1179,7 @@ function createPlayer(user: ReturnType<typeof mockUser>, isReady = false): Playe
     hand: [],
     cardCount: 0,
     isReady,
+    isConnected: true,
     isOut: false,
     role: 'PLAYER',
   };
@@ -1190,6 +1191,7 @@ function createSpectator(user: ReturnType<typeof mockUser>): Player {
     hand: [],
     cardCount: 0,
     isReady: false,
+    isConnected: true,
     isOut: false,
     role: 'SPECTATOR',
   };

--- a/src/modules/game/turn-manager.service.spec.ts
+++ b/src/modules/game/turn-manager.service.spec.ts
@@ -432,6 +432,7 @@ function createPlayer(
     hand: [],
     cardCount: 0,
     isReady: true,
+    isConnected: true,
     isOut: false,
     role: 'PLAYER',
     ...overrides,

--- a/src/modules/game/validators/attack-card-action.validator.spec.ts
+++ b/src/modules/game/validators/attack-card-action.validator.spec.ts
@@ -46,6 +46,7 @@ describe('AttackCardValidator', () => {
     isGuest: false,
     isOut: false,
     isReady: true,
+    isConnected: true,
     cardCount: 1,
     hand: [createMockCard()],
     ...overrides,

--- a/src/modules/game/validators/base-action.validator.spec.ts
+++ b/src/modules/game/validators/base-action.validator.spec.ts
@@ -49,6 +49,7 @@ describe('BaseActionValidator', () => {
     isOut: false,
     cardCount: 1,
     isReady: true,
+    isConnected: true,
     hand: [createMockCard()],
     ...overrides,
   });

--- a/src/modules/game/validators/card-action.validator.spec.ts
+++ b/src/modules/game/validators/card-action.validator.spec.ts
@@ -52,6 +52,7 @@ describe('CardActionValidator', () => {
     isGuest: false,
     isOut: false,
     isReady: true,
+    isConnected: true,
     cardCount: 1,
     hand: [createMockCard()],
     ...overrides,

--- a/src/modules/game/validators/normal-card-action.validator.spec.ts
+++ b/src/modules/game/validators/normal-card-action.validator.spec.ts
@@ -45,6 +45,7 @@ describe('NormalCardValidator', () => {
     isGuest: false,
     isOut: false,
     isReady: true,
+    isConnected: true,
     cardCount: 1,
     hand: [createMockCard()],
     ...overrides,

--- a/src/modules/game/validators/special-card-validator.spec.fixture.ts
+++ b/src/modules/game/validators/special-card-validator.spec.fixture.ts
@@ -38,6 +38,7 @@ export function createSpecialValidatorFixtures(
     isGuest: false,
     isOut: false,
     isReady: true,
+    isConnected: true,
     cardCount: 1,
     hand: [createMockCard()],
     ...overrides,

--- a/src/modules/game/validators/wildcard-action.validator.spec.ts
+++ b/src/modules/game/validators/wildcard-action.validator.spec.ts
@@ -45,6 +45,7 @@ describe('WildcardActionValidator', () => {
     isGuest: false,
     isOut: false,
     isReady: true,
+    isConnected: true,
     cardCount: 1,
     hand: [createMockCard()],
     ...overrides,

--- a/src/modules/game/victory.service.spec.ts
+++ b/src/modules/game/victory.service.spec.ts
@@ -115,6 +115,7 @@ function createPlayer(
     hand,
     cardCount: hand.length,
     isReady: true,
+    isConnected: true,
     isOut: false,
     role: 'PLAYER',
     ...overrides,

--- a/src/modules/socket/dto/game-room.response.dto.spec.ts
+++ b/src/modules/socket/dto/game-room.response.dto.spec.ts
@@ -76,6 +76,55 @@ describe('GameRoomResponseDto', () => {
     expect(serialized.lastActionId).toBe(7);
   });
 
+  it('Snapshot 복구 필드는 직렬화 시 포함되어야 한다', () => {
+    const room: GameRoom = {
+      roomId: 'room-1',
+      hostId: 'host-1',
+      attackStack: 4,
+      currentPower: 2,
+      lastCard: createMockCard({
+        suit: CardSuit.BEAR,
+        declaredSuit: CardSuit.CAT,
+      }),
+      drawPile: [],
+      discardPile: [],
+      lastActionId: 7,
+      turnOwner: 'me',
+      isBonusTurn: false,
+      direction: GameDirection.CLOCKWISE,
+      status: GameStatus.PLAYING,
+      winnerId: null,
+      winReason: null,
+      recentLogs: [],
+      players: [
+        {
+          userId: 'me',
+          nickname: 'me',
+          isGuest: false,
+          hand: [createMockCard()],
+          cardCount: 1,
+          isReady: true,
+          isConnected: false,
+          disconnectedAt: 1234567890,
+          isOut: false,
+          role: 'PLAYER',
+        },
+      ],
+    };
+
+    const dto = plainToInstance(GameRoomResponseDto, room, {
+      excludeExtraneousValues: true,
+    });
+    const serialized = JSON.parse(JSON.stringify(dto));
+
+    expect(serialized.hostId).toBe('host-1');
+    expect(serialized.currentPower).toBe(2);
+    expect(serialized.lastCard.declaredSuit).toBe(CardSuit.CAT);
+    expect(serialized.players[0].isReady).toBe(true);
+    expect(serialized.players[0].isConnected).toBe(false);
+    expect(serialized.players[0].disconnectedAt).toBe(1234567890);
+  });
+
   it('게임 종료 정보는 직렬화 시 포함되어야 한다', () => {
     const room: GameRoom = {
       roomId: 'room-1',

--- a/src/modules/socket/dto/game-room.response.dto.ts
+++ b/src/modules/socket/dto/game-room.response.dto.ts
@@ -11,6 +11,7 @@ import {
 export class CardResponseDto {
   @Expose() id!: string;
   @Expose() suit!: CardSuit;
+  @Expose() declaredSuit!: CardSuit;
   @Expose() type!: CardType;
   @Expose() value!: string;
   @Expose() power!: number;
@@ -23,6 +24,9 @@ export class PlayerResponseDto {
   @Expose() nickname!: string;
   @Expose() role!: 'PLAYER' | 'SPECTATOR';
   @Expose() cardCount!: number;
+  @Expose() isReady!: boolean;
+  @Expose() isConnected!: boolean;
+  @Expose() disconnectedAt!: number | null;
   @Expose() isOut!: boolean;
   
   @Expose()
@@ -33,10 +37,12 @@ export class PlayerResponseDto {
 @Exclude()
 export class GameRoomResponseDto {
   @Expose() roomId!: string;
+  @Expose() hostId!: string;
   @Expose() turnOwner!: string | null;
   @Expose() isBonusTurn!: boolean;
   @Expose() direction!: GameDirection;
   @Expose() attackStack!: number;
+  @Expose() currentPower!: number;
   @Expose() status!: GameStatus;
   @Expose() winnerId!: string | null;
   @Expose() winReason!: WinReason | null;

--- a/src/modules/socket/game.gateway.spec.ts
+++ b/src/modules/socket/game.gateway.spec.ts
@@ -735,6 +735,26 @@ describe('GameGateway disconnect cleanup', () => {
       }),
     );
   });
+
+  it('disconnect timeout이 이미 삭제된 방에서도 안전하게 종료되어야 한다', () => {
+    const host = mockUser(false);
+    const guest = mockUser();
+    const room = roomService.createRoom(host);
+
+    roomService.joinRoom(room.roomId, guest);
+    gateway.handleDisconnect(createClient(guest));
+
+    roomService.leaveRoom(guest.userId);
+    roomService.leaveRoom(host.userId);
+
+    expect(() => {
+      jest.advanceTimersByTime(30_000);
+    }).not.toThrow();
+
+    expect(victoryService.determineWinner).not.toHaveBeenCalled();
+    expect(gameService.finishGame).not.toHaveBeenCalled();
+    expect(roomService.getRoom(room.roomId)).toBeUndefined();
+  });
 });
 
 function createClient(user: SocketData['user']): Socket {

--- a/src/modules/socket/game.gateway.spec.ts
+++ b/src/modules/socket/game.gateway.spec.ts
@@ -401,6 +401,8 @@ describe('GameGateway', () => {
           hand: [],
           cardCount: 0,
           isReady: true,
+          isConnected: true,
+          disconnectedAt: null,
           isOut: false,
           role: 'PLAYER',
         },
@@ -470,6 +472,8 @@ describe('GameGateway', () => {
             hand: [],
             cardCount: 0,
             isReady: false,
+            isConnected: true,
+            disconnectedAt: null,
             isOut: false,
             role: 'SPECTATOR',
           },
@@ -586,6 +590,8 @@ describe('GameGateway disconnect cleanup', () => {
   let gameActionQueue: jest.Mocked<GameActionQueue>;
 
   beforeEach(() => {
+    jest.useFakeTimers();
+
     authService = createMock<AuthService>();
     gameService = createMock<GameService>();
     turnManager = createMock<TurnManagerService>();
@@ -608,7 +614,12 @@ describe('GameGateway disconnect cleanup', () => {
     } as unknown as Server;
   });
 
-  it('disconnect 시 players 목록에서 제거되어야 한다', () => {
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('disconnect 시 players 목록에서 제거되지 않아야 한다', () => {
     const host = mockUser(false);
     const guest = mockUser();
     const room = roomService.createRoom(host);
@@ -617,10 +628,10 @@ describe('GameGateway disconnect cleanup', () => {
     gateway.handleDisconnect(createClient(guest));
 
     const updatedRoom = roomService.getRoom(room.roomId);
-    expect(updatedRoom?.players.some((player) => player.userId === guest.userId)).toBe(false);
+    expect(updatedRoom?.players.some((player) => player.userId === guest.userId)).toBe(true);
   });
 
-  it('disconnect 시 userToRoom 인덱스가 제거되어야 한다', () => {
+  it('disconnect 시 userToRoom 인덱스가 유지되어야 한다', () => {
     const host = mockUser(false);
     const guest = mockUser();
     const room = roomService.createRoom(host);
@@ -628,67 +639,58 @@ describe('GameGateway disconnect cleanup', () => {
 
     gateway.handleDisconnect(createClient(guest));
 
-    expect(roomService.getUserRoom(guest.userId)).toBeUndefined();
+    expect(roomService.getUserRoom(guest.userId)).toBe(room.roomId);
   });
 
-  it('방장 disconnect 시 host가 다른 플레이어에게 이관되어야 한다', () => {
+  it('disconnect 시 isConnected만 false가 되어야 한다', () => {
     const host = mockUser(false);
     const guest = mockUser();
     const room = roomService.createRoom(host);
     roomService.joinRoom(room.roomId, guest);
 
-    gateway.handleDisconnect(createClient(host));
+    gateway.handleDisconnect(createClient(guest));
 
     const updatedRoom = roomService.getRoom(room.roomId);
-    expect(updatedRoom?.hostId).toBe(guest.userId);
+    expect(updatedRoom?.players.find((player) => player.userId === guest.userId)?.isConnected).toBe(false);
   });
 
-  it('턴 오너 disconnect 시 다음 턴 유저에게 턴이 넘어가야 한다', () => {
+  it('disconnect 시 hand와 room이 유지되어야 한다', () => {
     const host = mockUser(false);
-    const guest1 = mockUser();
-    const guest2 = mockUser();
+    const guest = mockUser();
     const room = roomService.createRoom(host);
+    const updatedRoom = roomService.joinRoom(room.roomId, guest);
+    const joinedPlayer = updatedRoom.players.find((player) => player.userId === guest.userId)!;
+    joinedPlayer.hand = [{
+      id: uuidv4(),
+      suit: CardSuit.RABBIT,
+      declaredSuit: CardSuit.RABBIT,
+      type: CardType.NUMBER,
+      power: 0,
+      value: '1',
+      assetKey: 'rabbit_1',
+    }];
+    joinedPlayer.cardCount = 1;
 
-    turnManager.resolveTurnAfterLeave.mockReturnValue(
-      guest1.userId,
-    );
+    gateway.handleDisconnect(createClient(guest));
 
-    roomService.joinRoom(room.roomId, guest1);
-    roomService.joinRoom(room.roomId, guest2);
+    const roomAfterDisconnect = roomService.getRoom(room.roomId);
+    expect(roomAfterDisconnect?.roomId).toBe(room.roomId);
+    expect(roomAfterDisconnect?.players.find((player) => player.userId === guest.userId)?.hand).toHaveLength(1);
+  });
 
+  it('disconnect 직후에는 방장 위임이나 턴 이동이 일어나지 않아야 한다', () => {
+    const host = mockUser(false);
+    const guest = mockUser();
+    const room = roomService.createRoom(host);
+    roomService.joinRoom(room.roomId, guest);
     room.status = 'PLAYING';
-    room.direction = GameDirection.CLOCKWISE;
     room.turnOwner = host.userId;
 
     gateway.handleDisconnect(createClient(host));
 
     const updatedRoom = roomService.getRoom(room.roomId);
-    expect(updatedRoom?.turnOwner).toBe(guest1.userId);
-  });
-
-  it('마지막 유저 disconnect 시 방이 삭제되어야 한다', () => {
-    const host = mockUser(false);
-    const room = roomService.createRoom(host);
-
-    gateway.handleDisconnect(createClient(host));
-
-    expect(roomService.getRoom(room.roomId)).toBeUndefined();
-  });
-
-  it('disconnect 후 재접속 시 already in a room 오류 없이 다시 입장할 수 있어야 한다', () => {
-    const host = mockUser(false);
-    const guest = mockUser();
-    const room = roomService.createRoom(host);
-
-    roomService.joinRoom(room.roomId, guest);
-    gateway.handleDisconnect(createClient(guest));
-
-    expect(() => {
-      roomService.joinRoom(room.roomId, guest);
-    }).not.toThrow(WsException);
-
-    const updatedRoom = roomService.getRoom(room.roomId);
-    expect(updatedRoom?.players.some((player) => player.userId === guest.userId)).toBe(true);
+    expect(updatedRoom?.hostId).toBe(host.userId);
+    expect(updatedRoom?.turnOwner).toBe(host.userId);
   });
 
   it('disconnect에서는 승리 판정을 시도하지 않아야 한다', () => {
@@ -700,6 +702,38 @@ describe('GameGateway disconnect cleanup', () => {
     gateway.handleDisconnect(createClient(guest));
 
     expect(victoryService.determineWinner).not.toHaveBeenCalled();
+  });
+
+  it('유예시간이 지나도 복귀하지 않으면 실제 leaveRoom과 승리 판정을 수행해야 한다', () => {
+    const host = mockUser(false);
+    const guest = mockUser();
+    const room = roomService.createRoom(host);
+    const emit = jest.fn();
+
+    gateway.server = {
+      to: jest.fn().mockReturnValue({
+        emit,
+      }),
+    } as unknown as Server;
+
+    roomService.joinRoom(room.roomId, guest);
+    gateway.handleDisconnect(createClient(guest));
+
+    jest.advanceTimersByTime(30_000);
+
+    expect(roomService.getUserRoom(guest.userId)).toBeUndefined();
+    expect(victoryService.determineWinner).toHaveBeenCalledWith({
+      room: expect.any(Object),
+      trigger: 'PLAYER_LEFT',
+      actorId: guest.userId,
+    });
+    expect(gameService.finishGame).toHaveBeenCalled();
+    expect(emit).toHaveBeenCalledWith(
+      SocketEvent.GAME_OVER,
+      expect.objectContaining({
+        winnerId: room.winnerId,
+      }),
+    );
   });
 });
 

--- a/src/modules/socket/game.gateway.ts
+++ b/src/modules/socket/game.gateway.ts
@@ -49,6 +49,8 @@ export const SocketValidationConfig = new ValidationPipe({
 export class GameGateway implements OnGatewayInit, OnGatewayConnection, OnGatewayDisconnect {
   @WebSocketServer() server!: Server;
   private logger: Logger = new Logger('GameGateway');
+  private readonly disconnectTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  private readonly DISCONNECT_GRACE_MS = 30_000;
 
   constructor(
     private readonly authService: AuthService,
@@ -107,6 +109,8 @@ export class GameGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
   handleLeaveRoom(
     @ConnectedSocket() client: Socket,
   ) {
+    this.clearDisconnectTimeout(client.data.user.userId);
+
     const { room, roomId, isDeleted } = this.roomService.leaveRoom(client.data.user.userId);
     const victory = room
       ? this.victoryService.determineWinner({
@@ -276,16 +280,16 @@ export class GameGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
       return;
     }
 
-    // TODO (ANI-15): 재접속 시 세션 복구를 지원할 수 있도록 disconnect와 명시적 leaveRoom 처리를 분리할 예정
-    const { room, roomId, isDeleted } = this.roomService.leaveRoom(user.userId);
+    const room = this.roomService.markDisconnected(user.userId);
+    this.scheduleDisconnectTimeout(user.userId);
 
     this.logger.log(`User Disconnected: ${user.nickname} (${user.userId})`);
     this.logger.log(`접속 해제: ${client.id}`);
 
-    if (roomId) {
-      this.server.to(roomId).emit(SocketEvent.ROOM_UPDATED, {
+    if (room) {
+      this.server.to(room.roomId).emit(SocketEvent.ROOM_UPDATED, {
         room,
-        message: `${user.nickname}님이 연결 해제되었습니다. ${isDeleted ? '방이 삭제되었습니다.' : ''}`,
+        message: `${user.nickname}님이 연결 해제되었습니다. ${this.DISCONNECT_GRACE_MS / 1000}초 내에 복귀하지 않으면 방에서 퇴장 처리됩니다.`,
       });
     }
 
@@ -364,6 +368,73 @@ export class GameGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
     );
 
     return this.gameService.getGameState(user.userId);
+  }
+
+  private scheduleDisconnectTimeout(userId: string): void {
+    this.clearDisconnectTimeout(userId);
+
+    const timer = setTimeout(() => {
+      this.handleDisconnectTimeout(userId);
+    }, this.DISCONNECT_GRACE_MS);
+
+    this.disconnectTimers.set(userId, timer);
+  }
+
+  private clearDisconnectTimeout(userId: string): void {
+    const timer = this.disconnectTimers.get(userId);
+    if (!timer) {
+      return;
+    }
+
+    clearTimeout(timer);
+    this.disconnectTimers.delete(userId);
+  }
+
+  private handleDisconnectTimeout(userId: string): void {
+    this.clearDisconnectTimeout(userId);
+
+    const roomBeforeLeave = this.roomService.getUserRoom(userId);
+    if (!roomBeforeLeave) {
+      return;
+    }
+
+    const roomSnapshot = this.roomService.getRoom(roomBeforeLeave);
+    const player =
+      roomSnapshot?.players.find((candidate) => candidate.userId === userId);
+
+    if (!roomSnapshot || !player || player.isConnected) {
+      return;
+    }
+
+    const { room, roomId, isDeleted } = this.roomService.leaveRoom(userId);
+    const victory = room
+      ? this.victoryService.determineWinner({
+          room,
+          trigger: VictoryTrigger.PLAYER_LEFT,
+          actorId: userId,
+        })
+      : null;
+
+    if (room && victory) {
+      this.gameService.finishGame(room, victory);
+    }
+
+    if (!roomId) {
+      return;
+    }
+
+    this.server.to(roomId).emit(SocketEvent.ROOM_UPDATED, {
+      room,
+      message: `${player.nickname}님이 복귀하지 않아 방에서 퇴장 처리되었습니다.${isDeleted ? ' 방이 삭제되었습니다.' : ''}`,
+    });
+
+    if (room && victory) {
+      this.server.to(roomId).emit(SocketEvent.GAME_OVER, {
+        winnerId: room.winnerId,
+        winReason: room.winReason,
+        message: `${victory.winner.nickname}님이 마지막 플레이어로 남아 승리했습니다.`,
+      });
+    }
   }
 
   private buildJoinRoomMessage(

--- a/src/modules/socket/masking.service.spec.ts
+++ b/src/modules/socket/masking.service.spec.ts
@@ -38,6 +38,7 @@ describe('MaskingService', () => {
           hand: Array.from({ length: 7 }, () => createMockCard()),
           cardCount: 7,
           isReady: true,
+          isConnected: true,
           isOut: false,
           role: 'PLAYER',
         },
@@ -48,6 +49,7 @@ describe('MaskingService', () => {
           hand: Array.from({ length: 7 }, () => createMockCard()),
           cardCount: 7,
           isReady: true,
+          isConnected: true,
           isOut: false,
           role: 'PLAYER',
         },
@@ -92,7 +94,7 @@ describe('MaskingService', () => {
     // 관전자 추가
     room.players.push({
       userId: 'spec', nickname: 'spec', isGuest: true,
-      hand: [], cardCount: 0, isReady: false, isOut: false, role: 'SPECTATOR',
+      hand: [], cardCount: 0, isReady: false, isConnected: true, isOut: false, role: 'SPECTATOR',
     });
 
     const result = service.maskRoomForUser(room, 'spec');
@@ -115,6 +117,7 @@ describe('MaskingService', () => {
       hand: Array.from({ length: 7 }, () => createMockCard()), // 일부러 넣어둠
       cardCount: 7,
       isReady: false,
+      isConnected: true,
       isOut: false,
       role: 'SPECTATOR',
     });

--- a/src/modules/socket/room.service.spec.ts
+++ b/src/modules/socket/room.service.spec.ts
@@ -59,6 +59,7 @@ describe('RoomService', () => {
       expect(room.players[0]).toMatchObject({
         userId: host.userId,
         isReady: true,
+        isConnected: true,
         role: 'PLAYER',
         hand: [],
         cardCount: 0,
@@ -89,6 +90,7 @@ describe('RoomService', () => {
         hand: [],
         cardCount: 0,
         isReady: false,
+        isConnected: true,
         role: 'PLAYER',
       });
 
@@ -257,6 +259,45 @@ describe('RoomService', () => {
     });
   });
 
+  describe('markDisconnected', () => {
+    let host: ReturnType<typeof mockUser>;
+    let room: GameRoom;
+
+    beforeEach(() => {
+      host = mockUser();
+      room = service.createRoom(host);
+    });
+
+    it('disconnect 시 player와 hand와 room은 유지하고 isConnected만 false로 바꿔야 한다', () => {
+      const guest = mockUser();
+      const updatedRoom = service.joinRoom(room.roomId, guest);
+      const joinedPlayer = updatedRoom.players.find((player) => player.userId === guest.userId)!;
+
+      joinedPlayer.hand = [{
+        id: uuidv4(),
+        suit: 'DOG' as any,
+        declaredSuit: 'DOG' as any,
+        type: 'NUMBER' as any,
+        value: '1',
+        power: 0,
+        assetKey: 'dog_1',
+      }];
+      joinedPlayer.cardCount = 1;
+
+      const roomAfterDisconnect = service.markDisconnected(guest.userId);
+
+      expect(roomAfterDisconnect?.roomId).toBe(room.roomId);
+      expect(service.getUserRoom(guest.userId)).toBe(room.roomId);
+      expect(roomAfterDisconnect?.players.some((player) => player.userId === guest.userId)).toBe(true);
+      expect(roomAfterDisconnect?.players.find((player) => player.userId === guest.userId)).toMatchObject({
+        isConnected: false,
+        disconnectedAt: expect.any(Number),
+        cardCount: 1,
+      });
+      expect(roomAfterDisconnect?.players.find((player) => player.userId === guest.userId)?.hand).toHaveLength(1);
+    });
+  });
+
   describe('toggleReady', () => {
     let host: ReturnType<typeof mockUser>;
     let room: GameRoom;
@@ -392,9 +433,9 @@ describe('RoomService', () => {
       const guestPlayer = updatedRoom.players.find((player) => player.userId === guest.userId);
       const spectatorPlayer = updatedRoom.players.find((player) => player.userId === spectator.userId);
 
-      expect(hostPlayer).toMatchObject({ role: 'PLAYER', isReady: true, isOut: false, hand: [], cardCount: 0 });
-      expect(guestPlayer).toMatchObject({ role: 'PLAYER', isReady: false, isOut: false, hand: [], cardCount: 0 });
-      expect(spectatorPlayer).toMatchObject({ role: 'SPECTATOR', isReady: false, isOut: false, hand: [], cardCount: 0 });
+      expect(hostPlayer).toMatchObject({ role: 'PLAYER', isReady: true, isConnected: true, isOut: false, hand: [], cardCount: 0 });
+      expect(guestPlayer).toMatchObject({ role: 'PLAYER', isReady: false, isConnected: true, isOut: false, hand: [], cardCount: 0 });
+      expect(spectatorPlayer).toMatchObject({ role: 'SPECTATOR', isReady: false, isConnected: true, isOut: false, hand: [], cardCount: 0 });
       expect(updatedRoom.recentLogs.at(-1)?.payload).toMatchObject({
         message: '다음 게임 준비를 위해 로비 상태로 전환되었습니다.',
       });

--- a/src/modules/socket/room.service.ts
+++ b/src/modules/socket/room.service.ts
@@ -34,6 +34,32 @@ export class RoomService {
     return this.userToRoom.get(userId);
   }
 
+  markDisconnected(userId: string): GameRoom | null {
+    const roomId = this.userToRoom.get(userId);
+    if (!roomId) {
+      this.logger.debug('markDisconnected skipped: User is not in any room');
+      return null;
+    }
+
+    const room = this.rooms.get(roomId);
+    if (!room) {
+      this.logger.debug('markDisconnected skipped: Room not found');
+      return null;
+    }
+
+    const player = room.players.find((candidate) => candidate.userId === userId);
+    if (!player) {
+      this.logger.warn(
+        'markDisconnected skipped: userToRoom index exists but user not found in room players',
+      );
+      return null;
+    }
+
+    player.isConnected = false;
+    player.disconnectedAt = Date.now();
+    return room;
+  }
+
   createRoom(user: SocketData['user']): GameRoom {
     // 유저가 이미 참여 중인 방이 있는지 확인
     const alreadyInRoom = this.getUserRoom(user.userId);
@@ -51,6 +77,8 @@ export class RoomService {
       hand: [],
       cardCount: 0,
       isReady: true, // 방장은 기본 준비 상태
+      isConnected: true,
+      disconnectedAt: null,
       isOut: false,
       role: 'PLAYER',
     };
@@ -102,6 +130,8 @@ export class RoomService {
       hand: [],
       cardCount: 0,
       isReady: false,
+      isConnected: true,
+      disconnectedAt: null,
       isOut: false,
       role,
     };
@@ -131,6 +161,8 @@ export class RoomService {
         - userToRoom index exists but user not found in room players`);
       return { room: null, roomId: null, isDeleted: false };
     }
+
+    room.players[leavingIndex].isConnected = false;
 
     const isTurnOwner = room.turnOwner === userId;
     const remainingPlayers = room.players.filter(
@@ -260,6 +292,8 @@ export class RoomService {
       ...player,
       hand: [],
       cardCount: 0,
+      isConnected: true,
+      disconnectedAt: null,
       isOut: false,
       isReady:
         player.role === 'PLAYER' &&

--- a/src/shared/interfaces/game.interface.ts
+++ b/src/shared/interfaces/game.interface.ts
@@ -24,6 +24,8 @@ export interface Player {
   hand: Card[]; // 개인에게 보여지는 카드덱 (서버에서 마스킹)
   cardCount: number; // 현재 들고 있는 카드의 개수 (공유가능)
   isReady: boolean;
+  isConnected: boolean;
+  disconnectedAt: number | null;
   isOut: boolean;
   role: 'PLAYER' | 'SPECTATOR';
 }


### PR DESCRIPTION
## 📝 변경 배경
게임 중 새로고침이나 일시적인 네트워크 끊김이 발생했을 때, 서버가 플레이어 상태를 너무 빨리 제거하면 이후 세션 복구를 설계하기가 어려웠습니다. 이번 작업은 `disconnect`를 즉시 퇴장으로 처리하지 않고, Snapshot을 복구 가능한 형태로 보존하도록 서버 상태 모델을 정비하는 데 초점을 맞췄습니다.

## 🚪 disconnect와 leaveRoom 책임 분리
가장 큰 변경은 `handleDisconnect()`가 더 이상 즉시 `leaveRoom()`을 호출하지 않도록 바꾼 점입니다. 이제 disconnect 시에는 플레이어를 방에서 제거하지 않고, `markDisconnected()`를 통해 연결 상태만 오프라인으로 전환한 뒤 유예시간을 시작합니다. 실제 퇴장은 timeout 시점에만 수행되므로, `Player`, `hand`, `room`, `userToRoom`이 모두 유지됩니다.

## ⏳ 지연 퇴장(timeout leave) 구조 도입
게이트웨이 내부에 disconnect timeout 관리 로직을 추가해, 유저가 일정 시간 내 복귀하지 않을 때만 실제 `leaveRoom()`과 후속 승리 판정이 실행되도록 만들었습니다. 이 구조로 “일시 끊김”과 “실제 이탈”을 명확히 분리했고, 영원히 돌아오지 않는 유저도 서버에서 정리할 수 있게 했습니다.

## 🧍 Snapshot 모델 확장
Snapshot 복구에 필요한 메타데이터를 `Player`와 응답 DTO에 추가했습니다. 플레이어에는 `isConnected`, `disconnectedAt`가 들어가고, Snapshot 응답에는 `hostId`, `currentPower`, `declaredSuit`, `players.isReady`, `players.isConnected`, `players.disconnectedAt`가 포함됩니다. 이를 통해 재접속 시 필요한 상태를 클라이언트가 더 완전하게 복원할 수 있는 기반을 마련했습니다.

## 🛡️ 보안 정책 유지
상태 정보는 늘렸지만, 보안 모델은 유지했습니다. 여전히 본인 외 플레이어의 `hand`는 마스킹되고, 상대에게는 `cardCount`와 연결/준비 상태 같은 메타 정보만 노출됩니다. 즉 Snapshot 완성도를 높이면서도 상대 패 노출 위험은 그대로 막았습니다.

## 🧪 테스트 정비

disconnect 관련 테스트를 새 상태 전이에 맞게 전면 수정했습니다. disconnect 직후 플레이어가 제거되지 않는지, `hand`와 `room`이 유지되는지, `isConnected`와 `disconnectedAt`이 올바르게 반영되는지, timeout 이후 실제 퇴장과 승리 판정이 수행되는지를 검증했습니다. Snapshot DTO 직렬화 테스트도 함께 보강했습니다.

추가로, disconnect 시 예약된 timeout이 이후 방이 이미 삭제된 상태에서 뒤늦게 실행되더라도 예외 없이 안전하게 종료되는 방어 케이스를 검증했습니다. 이를 통해 오래된(stale) timeout 콜백이 현재 서버 상태에 영향을 주지 않고 안전하게 무시되는 동작을 보장합니다.


## 📌 설계 포인트
이번 PR은 “세션 보존”까지만 다룹니다. 즉, 서버가 복구 가능한 상태를 유지하도록 만드는 것이 목표이며, 실제 “재접속 시 기존 플레이어로 복귀”하는 흐름은 의도적으로 포함하지 않았습니다. 이 부분은 후속 티켓인 ANI-15에서 `joinRoom` 재접속 분기, timeout 취소, 기존 hand 복구를 중심으로 이어서 구현할 예정입니다.

## ✅ 검증 결과
<img width="270" height="82" alt="image" src="https://github.com/user-attachments/assets/6eafcf77-fa43-436c-8101-5f7b92719fdd" />