### PR TITLE
test: add disconnectedAt to Player mocks

### DIFF
--- a/src/modules/game/actions/game-action-executor.service.spec.ts
+++ b/src/modules/game/actions/game-action-executor.service.spec.ts
@@ -157,6 +157,7 @@ function createPlayer(userId: string): Player {
     cardCount: 0,
     isReady: true,
     isConnected: true,
+    disconnectedAt: null,
     isOut: false,
     role: 'PLAYER',
   };

--- a/src/modules/game/game-setup.service.spec.ts
+++ b/src/modules/game/game-setup.service.spec.ts
@@ -105,6 +105,7 @@ describe('GameSetupService', () => {
       hand: [],
       isReady: true,
       isConnected: true,
+      disconnectedAt: null,
       isOut: false,
       role: 'PLAYER',
     });

--- a/src/modules/game/game.service.spec.ts
+++ b/src/modules/game/game.service.spec.ts
@@ -1180,6 +1180,7 @@ function createPlayer(user: ReturnType<typeof mockUser>, isReady = false): Playe
     cardCount: 0,
     isReady,
     isConnected: true,
+    disconnectedAt: null,
     isOut: false,
     role: 'PLAYER',
   };
@@ -1192,6 +1193,7 @@ function createSpectator(user: ReturnType<typeof mockUser>): Player {
     cardCount: 0,
     isReady: false,
     isConnected: true,
+    disconnectedAt: null,
     isOut: false,
     role: 'SPECTATOR',
   };

--- a/src/modules/game/turn-manager.service.spec.ts
+++ b/src/modules/game/turn-manager.service.spec.ts
@@ -433,6 +433,7 @@ function createPlayer(
     cardCount: 0,
     isReady: true,
     isConnected: true,
+    disconnectedAt: null,
     isOut: false,
     role: 'PLAYER',
     ...overrides,

--- a/src/modules/game/validators/attack-card-action.validator.spec.ts
+++ b/src/modules/game/validators/attack-card-action.validator.spec.ts
@@ -47,6 +47,7 @@ describe('AttackCardValidator', () => {
     isOut: false,
     isReady: true,
     isConnected: true,
+    disconnectedAt: null,
     cardCount: 1,
     hand: [createMockCard()],
     ...overrides,

--- a/src/modules/game/validators/base-action.validator.spec.ts
+++ b/src/modules/game/validators/base-action.validator.spec.ts
@@ -50,6 +50,7 @@ describe('BaseActionValidator', () => {
     cardCount: 1,
     isReady: true,
     isConnected: true,
+    disconnectedAt: null,
     hand: [createMockCard()],
     ...overrides,
   });

--- a/src/modules/game/validators/card-action.validator.spec.ts
+++ b/src/modules/game/validators/card-action.validator.spec.ts
@@ -53,6 +53,7 @@ describe('CardActionValidator', () => {
     isOut: false,
     isReady: true,
     isConnected: true,
+    disconnectedAt: null,
     cardCount: 1,
     hand: [createMockCard()],
     ...overrides,

--- a/src/modules/game/validators/normal-card-action.validator.spec.ts
+++ b/src/modules/game/validators/normal-card-action.validator.spec.ts
@@ -46,6 +46,7 @@ describe('NormalCardValidator', () => {
     isOut: false,
     isReady: true,
     isConnected: true,
+    disconnectedAt: null,
     cardCount: 1,
     hand: [createMockCard()],
     ...overrides,

--- a/src/modules/game/validators/special-card-validator.spec.fixture.ts
+++ b/src/modules/game/validators/special-card-validator.spec.fixture.ts
@@ -39,6 +39,7 @@ export function createSpecialValidatorFixtures(
     isOut: false,
     isReady: true,
     isConnected: true,
+    disconnectedAt: null,
     cardCount: 1,
     hand: [createMockCard()],
     ...overrides,

--- a/src/modules/game/validators/wildcard-action.validator.spec.ts
+++ b/src/modules/game/validators/wildcard-action.validator.spec.ts
@@ -46,6 +46,7 @@ describe('WildcardActionValidator', () => {
     isOut: false,
     isReady: true,
     isConnected: true,
+    disconnectedAt: null,
     cardCount: 1,
     hand: [createMockCard()],
     ...overrides,

--- a/src/modules/game/victory.service.spec.ts
+++ b/src/modules/game/victory.service.spec.ts
@@ -116,6 +116,7 @@ function createPlayer(
     cardCount: hand.length,
     isReady: true,
     isConnected: true,
+    disconnectedAt: null,
     isOut: false,
     role: 'PLAYER',
     ...overrides,

--- a/src/modules/socket/masking.service.spec.ts
+++ b/src/modules/socket/masking.service.spec.ts
@@ -39,6 +39,7 @@ describe('MaskingService', () => {
           cardCount: 7,
           isReady: true,
           isConnected: true,
+          disconnectedAt: null,
           isOut: false,
           role: 'PLAYER',
         },
@@ -50,6 +51,7 @@ describe('MaskingService', () => {
           cardCount: 7,
           isReady: true,
           isConnected: true,
+          disconnectedAt: null,
           isOut: false,
           role: 'PLAYER',
         },
@@ -94,7 +96,7 @@ describe('MaskingService', () => {
     // 관전자 추가
     room.players.push({
       userId: 'spec', nickname: 'spec', isGuest: true,
-      hand: [], cardCount: 0, isReady: false, isConnected: true, isOut: false, role: 'SPECTATOR',
+      hand: [], cardCount: 0, isReady: false, isConnected: true, disconnectedAt: null, isOut: false, role: 'SPECTATOR',
     });
 
     const result = service.maskRoomForUser(room, 'spec');
@@ -118,6 +120,7 @@ describe('MaskingService', () => {
       cardCount: 7,
       isReady: false,
       isConnected: true,
+      disconnectedAt: null,
       isOut: false,
       role: 'SPECTATOR',
     });


### PR DESCRIPTION
## 요약
`Player` 타입에 `disconnectedAt` 필드가 필수가 되면서, 테스트 코드의 mock 객체들도 이에 맞게 정리했습니다.

## 변경 사항
- 게임/소켓 관련 spec의 `Player` mock helper에 `disconnectedAt: null` 추가
- 인라인으로 작성된 `Player` mock에도 누락된 `disconnectedAt` 값 보완
- 현재 `Player` 인터페이스와 테스트 fixture를 일치시키도록 정리

## 작업 이유
세션 보존 모델 변경 이후 일부 테스트 코드에서 타입 불일치와 에디터 빨간줄이 발생하고 있었고, 이를 해소하기 위한 작은 후속 정리입니다.

## 검증
- `npm exec tsc -- --noEmit`
- `npm test -- --runInBand`